### PR TITLE
Implement admin leave

### DIFF
--- a/lib/members.js
+++ b/lib/members.js
@@ -23,6 +23,12 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
 var LOG_10 = Math.log(10);
+var MEMBER_STATUSES = {
+    alive: true,
+    faulty: true,
+    leave: true,
+    suspect: true
+};
 
 function Dissemination(ringpop) {
     this.ringpop = ringpop;
@@ -140,11 +146,36 @@ function Membership(ringpop) {
 
 util.inherits(Membership, EventEmitter);
 
+Membership.evalOverride = function evalOverride(member, change) {
+    if (Membership.isLocalSuspectOverride(member, change) || Membership.isLocalFaultyOverride(member, change)) {
+        // Local node should never allow itself to become suspect or faulty. In response,
+        // it affirms its "aliveness" and bumps its incarnation number.
+        member.status = 'alive';
+        member.incarnationNumber = +new Date();
+        return _.extend(member, { type: 'alive' });
+    } else if (Membership.isAliveOverride(member, change)) {
+        member.status = 'alive';
+        member.incarnationNumber = change.incarnationNumber || member.incarnationNumber;
+        return _.extend(member, { type: 'alive' });
+    } else if (Membership.isSuspectOverride(member, change)) {
+        member.status = 'suspect';
+        member.incarnationNumber = change.incarnationNumber || member.incarnationNumber;
+        return _.extend(member, { type: 'suspect' });
+    } else if (Membership.isFaultyOverride(member, change)) {
+        member.status = 'faulty';
+        member.incarnationNumber = change.incarnationNumber || member.incarnationNumber;
+        return _.extend(member, { type: 'faulty' });
+    } else if (Membership.isLeaveOverride(member, change)) {
+        member.status = 'leave';
+        member.incarnationNumber = change.incarnationNumber || member.incarnationNumber;
+        return _.extend(member, { type: 'leave' });
+    }
+};
+
 Membership.isAliveOverride = function isAliveOverride(member, change) {
     return change.status === 'alive' &&
-        ((member.status === 'suspect' && change.incarnationNumber > member.incarnationNumber) ||
-        (member.status === 'faulty' && change.incarnationNumber > member.incarnationNumber) ||
-        (member.status === 'alive' && change.incarnationNumber > member.incarnationNumber));
+        MEMBER_STATUSES[member.status] &&
+        change.incarnationNumber > member.incarnationNumber;
 };
 
 Membership.isFaultyOverride = function isFaultyOverride(member, change) {
@@ -152,6 +183,12 @@ Membership.isFaultyOverride = function isFaultyOverride(member, change) {
         ((member.status === 'suspect' && change.incarnationNumber >= member.incarnationNumber) ||
         (member.status === 'faulty' && change.incarnationNumber > member.incarnationNumber) ||
         (member.status === 'alive' && change.incarnationNumber > member.incarnationNumber));
+};
+
+Membership.isLeaveOverride = function isLeaveOverride(member, change) {
+    return change.status === 'leave' &&
+        MEMBER_STATUSES[member.status] &&
+        change.incarnationNumber > member.incarnationNumber;
 };
 
 Membership.isLocalFaultyOverride = function isLocalFaultyOverride(member, change) {
@@ -220,10 +257,6 @@ Membership.prototype.computeChecksum = function computeChecksum() {
     return this.checksum;
 };
 
-Membership.prototype.hasMember = function hasMember(member) {
-    return !!this.findMemberByAddress(member.address);
-};
-
 Membership.prototype.findMemberByAddress = function findMemberByAddress(address) {
     return _.find(this.members, function(member) {
         return member.address === address;
@@ -244,6 +277,10 @@ Membership.prototype.generateChecksumString = function generateChecksumString() 
 
 Membership.prototype.getJoinPosition = function getJoinPosition() {
     return Math.floor(Math.random() * (this.members.length - 0)) + 0;
+};
+
+Membership.prototype.getLocalMemberAddress = function getLocalMemberAddress() {
+    return this.localMember && this.localMember.address;
 };
 
 Membership.prototype.getMemberAt = function getMemberAt(index) {
@@ -283,6 +320,26 @@ Membership.prototype.getStats = function getStats() {
     };
 };
 
+Membership.prototype.hasMember = function hasMember(member) {
+    return !!this.findMemberByAddress(member.address);
+};
+
+Membership.prototype.makeAlive = function makeAlive() {
+    this.update([{
+        address: this.localMember.address,
+        status: 'alive',
+        incarnationNumber: +new Date()
+    }]);
+};
+
+Membership.prototype.makeLeave = function makeLeave() {
+    this.update([{
+        address: this.localMember.address,
+        status: 'leave',
+        incarnationNumber: +new Date()
+    }]);
+};
+
 Membership.prototype.shuffle = function shuffle() {
     this.members = _.shuffle(this.members);
 };
@@ -306,24 +363,10 @@ Membership.prototype.update = function update(changes) {
         var member = this.findMemberByAddress(change.address);
 
         if (member) {
-            if (Membership.isLocalSuspectOverride(member, change) || Membership.isLocalFaultyOverride(member, change)) {
-                // Local node should never allow itself to become suspect or faulty. In response,
-                // it affirms its "aliveness" and bumps its incarnation number.
-                member.status = 'alive';
-                member.incarnationNumber = +new Date();
-                updates.push(_.extend(member, { type: 'alive' }));
-            } else if (Membership.isAliveOverride(member, change)) {
-                member.status = 'alive';
-                member.incarnationNumber = change.incarnationNumber || member.incarnationNumber;
-                updates.push(_.extend(member, { type: 'alive' }));
-            } else if (Membership.isSuspectOverride(member, change)) {
-                member.status = 'suspect';
-                member.incarnationNumber = change.incarnationNumber || member.incarnationNumber;
-                updates.push(_.extend(member, { type: 'suspect' }));
-            } else if (Membership.isFaultyOverride(member, change)) {
-                member.status = 'faulty';
-                member.incarnationNumber = change.incarnationNumber || member.incarnationNumber;
-                updates.push(_.extend(member, { type: 'faulty' }));
+            var update = Membership.evalOverride(member, change);
+
+            if (update) {
+                updates.push(update);
             }
         } else {
             member = {

--- a/lib/swim.js
+++ b/lib/swim.js
@@ -17,6 +17,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+var clearTimeout = require('timers').clearTimeout;
+var globalSetTimeout = require('timers').setTimeout;
+var safeParse = require('./util').safeParse;
 var TypedError = require('error/typed');
 
 var NoHostsError = TypedError({
@@ -25,8 +28,6 @@ var NoHostsError = TypedError({
     type: 'ringpop.swim.no-hosts',
     bootstrapHosts: null
 });
-
-var safeParse = require('./util').safeParse;
 
 function AdminJoiner(params) {
     this.ringpop = params.ringpop;
@@ -171,7 +172,7 @@ AdminJoiner.prototype.rejoin = function rejoin() {
 
 AdminJoiner.prototype.destroy = function destroy() {
     clearTimeout(this.timer);
-}
+};
 
 function PingReqSender(ring, member, target, callback) {
     this.ring = ring;
@@ -264,8 +265,166 @@ PingSender.prototype.doCallback = function doCallback(isOk, bodyObj) {
     }
 };
 
+function Gossip(ringpop) {
+    this.ringpop = ringpop;
+    this.isStopped = true;
+    this.timer = null;
+}
+
+Gossip.prototype.run = function run() {
+    var self = this;
+
+    var protocolDelay = this.ringpop.computeProtocolDelay();
+    this.ringpop.stat('timing', 'protocol.delay', protocolDelay);
+
+    var startTime = new Date();
+    this.timer = setTimeout(function() {
+        self.ringpop.pingMemberNow(function() {
+            self.ringpop.stat('timing', 'protocol.frequency', startTime);
+
+            if (self.isStopped) {
+                self.ringpop.logger.debug('stopped recurring gossip loop', {
+                    local: self.ringpop.membership.getLocalMemberAddress()
+                });
+                return;
+            }
+
+            self.run();
+        });
+    }, protocolDelay);
+};
+
+Gossip.prototype.start = function start() {
+    if (!this.isStopped) {
+        this.ringpop.logger.debug('gossip has already started', {
+            local: this.ringpop.membership.getLocalMemberAddress()
+        });
+        return;
+    }
+
+    this.ringpop.membership.shuffle();
+    this.run();
+    this.isStopped = false;
+
+    this.ringpop.logger.debug('started gossip protocol', {
+        local: this.ringpop.membership.getLocalMemberAddress()
+    });
+};
+
+Gossip.prototype.stop = function stop() {
+    if (this.isStopped) {
+        this.ringpop.logger.warn('gossip is already stopped', {
+            local: this.ringpop.membership.getLocalMemberAddress()
+        });
+        return;
+    }
+
+    clearTimeout(this.timer);
+    this.timer = null;
+    this.isStopped = true;
+
+    this.ringpop.logger.debug('stopped gossip protocol', {
+        local: this.ringpop.membership.getLocalMemberAddress()
+    });
+};
+
+function Suspicion(ringpop) {
+    this.ringpop = ringpop;
+    this.isStoppedAll = null;
+    this.timers = {};
+    this.period = 5000;
+}
+
+Suspicion.prototype.reenable = function reenable() {
+    if (this.isStoppedAll !== true) {
+        this.ringpop.logger.warn('cannot reenable suspicion protocol because it was never disabled', {
+            local: this.ringpop.membership.getLocalMemberAddress()
+        });
+        return;
+    }
+
+    this.isStoppedAll = null;
+
+    this.ringpop.logger.debug('reenabled suspicion protocol', {
+        local: this.ringpop.membership.getLocalMemberAddress()
+    });
+};
+
+Suspicion.prototype.setTimeout = function setTimeout(fn) {
+    return globalSetTimeout(fn, this.period);
+};
+
+Suspicion.prototype.start = function start(member) {
+    if (this.isStoppedAll === true) {
+        this.ringpop.logger.debug('cannot start a suspect period because suspicion has not been reenabled', {
+            local: this.ringpop.membership.getLocalMemberAddress()
+        });
+        return;
+    }
+
+    if (member.address === this.ringpop.membership.getLocalMemberAddress()) {
+        this.ringpop.logger.debug('cannot start a suspect period for the local member', {
+            local: this.ringpop.membership.getLocalMemberAddress(),
+            suspect: member.address
+        });
+        return;
+    }
+
+    if (this.timers[member.address]) {
+        this.stop(member);
+    }
+
+    this.timers[member.address] = this.setTimeout(function() {
+        this.ringpop.membership.update([{
+            address: member.address,
+            incarnationNumber: member.incarnationNumber,
+            status: 'faulty'
+        }]);
+    }.bind(this));
+
+    this.ringpop.logger.debug('started suspect period', {
+        local: this.ringpop.membership.getLocalMemberAddress(),
+        suspect: member.address
+    });
+};
+
+Suspicion.prototype.stop = function stop(member) {
+    clearTimeout(this.timers[member.address]);
+    delete this.timers[member.address];
+
+    this.ringpop.logger.debug('stopped members suspect timer', {
+        local: this.ringpop.membership.getLocalMemberAddress(),
+        suspect: member.address
+    });
+};
+
+Suspicion.prototype.stopAll = function stopAll() {
+    this.isStoppedAll = true;
+
+    var timerKeys = Object.keys(this.timers);
+
+    if (timerKeys.length === 0) {
+        this.ringpop.logger.debug('stopped no suspect timers', {
+            local: this.ringpop.membership.getLocalMemberAddress()
+        });
+        return;
+    }
+
+    timerKeys.forEach(function clearSuspect(timerKey) {
+        clearTimeout(this.timers[timerKey]);
+        delete this.timers[timerKey];
+    }, this);
+
+    this.ringpop.logger.debug('stopped all suspect timers', {
+        local: this.ringpop.membership.getLocalMemberAddress(),
+        numTimers: timerKeys.length
+    });
+};
+
 module.exports = {
     AdminJoiner: AdminJoiner,
+    Gossip: Gossip,
     PingReqSender: PingReqSender,
-    PingSender: PingSender
+    PingSender: PingSender,
+    Suspicion: Suspicion
 };

--- a/lib/tchannel.js
+++ b/lib/tchannel.js
@@ -79,16 +79,16 @@ RingPopTChannel.prototype.adminDebugClear = function (arg1, arg2, hostInfo, cb) 
 };
 
 RingPopTChannel.prototype.adminGossip = function (arg1, arg2, hostInfo, cb) {
-    this.ringPop.startProtocolPeriod();
+    this.ringPop.gossip.start();
     cb(null, null, 'ok');
 };
 
 RingPopTChannel.prototype.adminLeave = function (arg1, arg2, hostInfo, cb) {
-    cb(new Error('not implemented'));
+    this.ringPop.adminLeave(cb);
 };
 
 RingPopTChannel.prototype.adminJoin = function (arg1, arg2, hostInfo, cb) {
-    var body = safeParse(arg2.toString());
+    var body = safeParse(arg2.toString()) || {};
     if (body) {
         this.ringPop.adminJoin(body.target, function (err, candidateHosts) {
             if (err) {

--- a/test/members_test.js
+++ b/test/members_test.js
@@ -33,3 +33,33 @@ test('checksum is changed when membership is updated', function t(assert) {
     assert.doesNotEqual(membership.checksum, prevChecksum, 'checksum is changed');
     assert.end();
 });
+
+test('change with higher incarnation number results in leave override', function t(assert) {
+    var member = { status: 'alive', incarnationNumber: 1 };
+    var change = { status: 'leave', incarnationNumber: 2 };
+
+    var update = Membership.evalOverride(member, change);
+
+    assert.equals(update.type, 'leave', 'results in leave');
+    assert.end();
+});
+
+test('change with same incarnation number does not result in leave override', function t(assert) {
+    var member = { status: 'alive', incarnationNumber: 1 };
+    var change = { status: 'leave', incarnationNumber: 1 };
+
+    var update = Membership.evalOverride(member, change);
+
+    assert.notok(update, 'no override');
+    assert.end();
+});
+
+test('change with lower incarnation number does not result in leave override', function t(assert) {
+    var member = { status: 'alive', incarnationNumber: 1 };
+    var change = { status: 'leave', incarnationNumber: 0 };
+
+    var update = Membership.evalOverride(member, change);
+
+    assert.notok(update, 'no override');
+    assert.end();
+});

--- a/test/mock/membership.js
+++ b/test/mock/membership.js
@@ -25,5 +25,15 @@ module.exports = {
         address: '127.0.0.1:3000',
         incarnationNumber: 123456789
     },
+    remoteMember: {
+        address: '127.0.0.1:3001',
+        incarnationNumber: 123456789
+    },
+    remoteMember2: {
+        address: '127.0.0.1:3002',
+        incarnationNumber: 123456789
+    },
+    getLocalMemberAddress: noop,
+    shuffle: noop,
     update: noop
 };

--- a/test/mock/noop.js
+++ b/test/mock/noop.js
@@ -17,9 +17,4 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-module.exports = {
-    channel: require('./channel.js'),
-    logger: require('./logger.js'),
-    membership: require('./membership.js'),
-    noop: require('./noop.js')
-};
+module.exports = function() {};

--- a/test/swim_test.js
+++ b/test/swim_test.js
@@ -18,9 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var AdminJoiner = require('../lib/swim.js').AdminJoiner;
 var mock = require('./mock');
 var test = require('tape');
+
+var AdminJoiner = require('../lib/swim.js').AdminJoiner;
+var Gossip = require('../lib/swim.js').Gossip;
+var Suspicion = require('../lib/swim.js').Suspicion;
+
+function createRingpop() {
+    return {
+        computeProtocolDelay: mock.noop,
+        logger: mock.logger,
+        membership: mock.membership,
+        stat: mock.noop
+    };
+}
+
+function createGossip() {
+    return new Gossip(createRingpop());
+}
+
+function createSuspicion() {
+    return new Suspicion(createRingpop());
+}
 
 test('join is aborted when max join duration is exceeded', function t(assert) {
     assert.plan(2);
@@ -41,5 +61,146 @@ test('join is aborted when max join duration is exceeded', function t(assert) {
     joiner.joinStart = new Date() - (86400 * 1000); // Started a day ago ;)
     joiner.sendJoin();
 
+    assert.end();
+});
+
+test('starting and stopping gossip sets timer / unsets timer', function t(assert) {
+    var gossip = createGossip();
+
+    gossip.start();
+    assert.ok(gossip.timer, 'timer was set');
+
+    gossip.stop();
+    assert.notok(gossip.timer, 'timer was cleared');
+
+    assert.end();
+});
+
+test('stopping gossip is a noop if gossip was never started', function t(assert) {
+    var gossip = createGossip();
+    gossip.timer = 'nochange';
+
+    gossip.stop();
+    assert.equals(gossip.timer, 'nochange', 'timer was not cleared');
+    assert.equals(gossip.isStopped, true, 'gossip was not stopped');
+
+    assert.end();
+});
+
+test('gossip can be restarted', function t(assert) {
+    var gossip = createGossip();
+    gossip.start();
+
+    gossip.stop();
+    assert.equals(gossip.timer, null, 'timer was cleared');
+    assert.equals(gossip.isStopped, true, 'gossip was stopped');
+
+    gossip.start();
+    assert.ok(gossip.timer, 'timer was set');
+    assert.equals(gossip.isStopped, false, 'gossip was started');
+
+    gossip.stop(); // Cleanup
+    assert.end();
+});
+
+test('suspect period for member is started', function t(assert) {
+    var member = { address: '127.0.0.1:3000' };
+    var suspicion = createSuspicion();
+
+    suspicion.start(member);
+    assert.ok(suspicion.timers[member.address], 'timer is set for member suspect period');
+
+    suspicion.stopAll(); // Cleanup
+    assert.end();
+});
+
+test('suspect period cannot be started for local member', function t(assert) {
+    var localMember = { address: '127.0.0.1:3000' };
+    var suspicion = createSuspicion();
+    suspicion.ringpop.membership.localMember = localMember;
+    suspicion.ringpop.membership.getLocalMemberAddress = function() { return localMember.address; };
+
+    suspicion.start(localMember);
+    assert.notok(suspicion.timers[localMember.address], 'timer is not set for local member suspect period');
+
+    suspicion.stopAll();
+    assert.end();
+});
+
+test('suspect period for member is stopped before another is started', function t(assert) {
+    assert.plan(2);
+
+    var suspicion = createSuspicion();
+    var remoteMember = suspicion.ringpop.membership.remoteMember;
+    suspicion.timers[remoteMember.address] = true;
+    suspicion.stop = function(member) {
+        assert.equals(member.address, remoteMember.address, 'stopping correct member period');
+        assert.pass('stop was called on previous suspect period');
+    };
+
+    suspicion.start(remoteMember);
+
+    suspicion.stopAll();
+    assert.end();
+});
+
+test('suspect period can\'t be started until reenabled', function t(assert) {
+    var suspicion = createSuspicion();
+    var remoteMember = suspicion.ringpop.membership.remoteMember;
+    suspicion.stopAll();
+
+    suspicion.start(remoteMember);
+    assert.notok(suspicion.timers[remoteMember.address], 'timer for member was not set');
+
+    suspicion.reenable();
+    assert.equals(suspicion.isStoppedAll, null, 'suspicion reenabled');
+
+    suspicion.start(remoteMember);
+    assert.ok(suspicion.timers[remoteMember.address], 'timer for member was set');
+
+    suspicion.stopAll();
+    assert.end();
+});
+
+test('suspect period stop all clears all timers', function t(assert) {
+    var suspicion = createSuspicion();
+    var remoteMember = suspicion.ringpop.membership.remoteMember;
+    var remoteMember2 = suspicion.ringpop.membership.remoteMember2;
+
+    suspicion.start(remoteMember);
+    suspicion.start(remoteMember2);
+    assert.ok(suspicion.timers[remoteMember.address], 'suspect timer started for first member');
+    assert.ok(suspicion.timers[remoteMember2.address], 'suspect timer started for next member');
+
+    suspicion.stopAll();
+    assert.notok(suspicion.timers[remoteMember.address], 'suspect timer clear for first member');
+    assert.notok(suspicion.timers[remoteMember2.address], 'suspect timer clear for next member');
+    assert.ok(suspicion.isStoppedAll, 'stopped all timers');
+
+    assert.end();
+});
+
+test('suspicion subprotocol cannot be reenabled without all timers first being stopped', function t(assert) {
+    var suspicion = createSuspicion();
+    suspicion.isStoppedAll = 'fakestopall';
+    suspicion.reenable();
+    assert.equals(suspicion.isStoppedAll, 'fakestopall', 'suspicion not reenabled');
+    assert.end();
+});
+
+test('marks member faulty after suspect period', function t(assert) {
+    assert.plan(2);
+
+    var suspicion = createSuspicion();
+    var member = suspicion.ringpop.membership.remoteMember;
+    suspicion.setTimeout = function(fn) { return fn(); };
+    suspicion.ringpop.membership.update = function(changes) {
+        assert.equals(changes[0].address, member.address, 'updates correct member');
+        assert.equals(changes[0].status, 'faulty', 'marks member faulty');
+    };
+
+    suspicion.start(member);
+
+    suspicion.stopAll();
     assert.end();
 });


### PR DESCRIPTION
Excuse all the churn here. 

The operation implemented is an /admin/leave which sets the local member status to leave and then disseminated to the protocol pingers. This operation is manual much like /admin/join. When a member is in the 'leave' status, the member is soft-removed from membership. It'll be removed from pingers lists and the ring itself. As part of the 'leave' operation, local gossip and suspect protocol are stopped. A member that has previously left can rejoin by /admin/join.

As part of this work I refactored and took the start/stop of gossip and suspicion subprotocol out into the lib/swim.js file. I think I left this code slightly better than it was. Still lots of room for improvement.

There's also a relatively high amount of test coverage here... which is good

@mranney @Raynos 