### PR TITLE
add hammock to dependencies

### DIFF
--- a/lib/request-proxy.js
+++ b/lib/request-proxy.js
@@ -21,7 +21,7 @@
 
 var body = require('body');
 var PassThrough = require('readable-stream').PassThrough;
-var hammock = require('hammock');
+var hammock = require('uber-hammock');
 var TypedError = require('error/typed');
 
 var safeParse = require('./util').safeParse;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "farmhash": "^0.2.0",
     "metrics": "^0.1.8",
     "readable-stream": "^1.0.33",
+    "uber-hammock": "^1.0.0",
     "underscore": "^1.5.2"
   },
   "devDependencies": {
@@ -31,7 +32,6 @@
     "debuglog": "^1.0.1",
     "format-stack": "^1.2.0",
     "glob": "^4.3.1",
-    "hammock": "git://github.com/Raynos/hammock#use-streams",
     "istanbul": "^0.3.5",
     "itape": "^1.5.0",
     "jshint": "^2.5.6",

--- a/test/lib/alloc-request.js
+++ b/test/lib/alloc-request.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var hammock = require('hammock');
+var hammock = require('uber-hammock');
 
 module.exports = allocRequest;
 

--- a/test/lib/alloc-response.js
+++ b/test/lib/alloc-response.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var hammock = require('hammock');
+var hammock = require('uber-hammock');
 var tryIt = require('tryit');
 
 module.exports = allocResponse;


### PR DESCRIPTION
Without `hammock` in dependencies, `require('ringpop')`
    just fails.

I had to fork hammock because reasons.

reviewers: @jwolski

cc: @sh1mmer