### PR TITLE
Faulty overrides alive member with same incarnation number

### DIFF
--- a/lib/members.js
+++ b/lib/members.js
@@ -182,7 +182,7 @@ Membership.isFaultyOverride = function isFaultyOverride(member, change) {
     return change.status === 'faulty' &&
         ((member.status === 'suspect' && change.incarnationNumber >= member.incarnationNumber) ||
         (member.status === 'faulty' && change.incarnationNumber > member.incarnationNumber) ||
-        (member.status === 'alive' && change.incarnationNumber > member.incarnationNumber));
+        (member.status === 'alive' && change.incarnationNumber >= member.incarnationNumber));
 };
 
 Membership.isLeaveOverride = function isLeaveOverride(member, change) {

--- a/test/members_test.js
+++ b/test/members_test.js
@@ -63,3 +63,22 @@ test('change with lower incarnation number does not result in leave override', f
     assert.notok(update, 'no override');
     assert.end();
 });
+
+test('member is able to go from alive to faulty without going through suspect', function t(assert) {
+    var aliveMember = {
+        status: 'alive',
+        incarnationNumber: 0
+    };
+
+    assert.notok(Membership.evalOverride(aliveMember, {
+        status: 'faulty',
+        incarnationNumber: -1
+    }), 'no override when incarnation number is lower');
+
+    assert.ok(Membership.evalOverride(aliveMember, {
+        status: 'faulty',
+        incarnationNumber: 0
+    }), 'override when incarnation number is same');
+
+    assert.end();
+});


### PR DESCRIPTION
While unlikely that suspect hasn't made its way around the cluster, given the 5s suspect period timeout, this will help fault detection in the event that a faulty member has been detected before suspect status has reached all nodes.

@mranney @mrhooray @Raynos 