### PR TITLE
Fix protocol period timing bug by updating the protocol timing metric af...

### DIFF
--- a/lib/swim.js
+++ b/lib/swim.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 var clearTimeout = require('timers').clearTimeout;
 var globalSetTimeout = require('timers').setTimeout;
+var metrics = require('metrics');
 var safeParse = require('./util').safeParse;
 var TypedError = require('error/typed');
 
@@ -267,20 +268,48 @@ PingSender.prototype.doCallback = function doCallback(isOk, bodyObj) {
 
 function Gossip(ringpop) {
     this.ringpop = ringpop;
+
     this.isStopped = true;
-    this.timer = null;
+    this.lastProtocolPeriod = Date.now();
+    this.lastProtocolRate = 0;
+    this.minProtocolPeriod = 200;
+    this.numProtocolPeriods = 0;
+    this.protocolTiming = new metrics.Histogram();
+    this.protocolTiming.update(this.minProtocolPeriod);
+    this.protocolPeriodTimer = null;
+    this.protocolRateTimer = null;
 }
+
+Gossip.prototype.computeProtocolDelay = function computeProtocolDelay() {
+    if (this.numProtocolPeriods) {
+        var target = this.lastProtocolPeriod + this.lastProtocolRate;
+        return Math.max(target - Date.now(), this.minProtocolPeriod);
+    } else {
+        // Delay for first tick will be staggered from 0 to `minProtocolPeriod` ms.
+        return Math.floor(Math.random() * (this.minProtocolPeriod + 1));
+    }
+};
+
+Gossip.prototype.computeProtocolRate = function computeProtocolRate() {
+    var observed = this.protocolTiming.percentiles([0.5])['0.5'] * 2;
+    return Math.max(observed, this.minProtocolPeriod);
+};
 
 Gossip.prototype.run = function run() {
     var self = this;
 
-    var protocolDelay = this.ringpop.computeProtocolDelay();
+    var protocolDelay = this.computeProtocolDelay();
     this.ringpop.stat('timing', 'protocol.delay', protocolDelay);
 
     var startTime = new Date();
-    this.timer = setTimeout(function() {
-        self.ringpop.pingMemberNow(function() {
+    this.protocolPeriodTimer = setTimeout(function onGossipTimer() {
+        var pingStartTime = Date.now();
+
+        self.ringpop.pingMemberNow(function onMemberPinged() {
+            self.lastProtocolPeriod = Date.now();
+            self.numProtocolPeriods++;
             self.ringpop.stat('timing', 'protocol.frequency', startTime);
+            self.protocolTiming.update(Date.now() - pingStartTime); // This keeps the protocol rate in check
 
             if (self.isStopped) {
                 self.ringpop.logger.debug('stopped recurring gossip loop', {
@@ -304,11 +333,19 @@ Gossip.prototype.start = function start() {
 
     this.ringpop.membership.shuffle();
     this.run();
+    this.startProtocolRateTimer();
     this.isStopped = false;
 
     this.ringpop.logger.debug('started gossip protocol', {
         local: this.ringpop.membership.getLocalMemberAddress()
     });
+};
+
+Gossip.prototype.startProtocolRateTimer = function startProtocolRateTimer() {
+    var self = this;
+    this.protocolRateTimer = setInterval(function () {
+        self.lastProtocolRate = self.computeProtocolRate();
+    }, 1000);
 };
 
 Gossip.prototype.stop = function stop() {
@@ -319,8 +356,12 @@ Gossip.prototype.stop = function stop() {
         return;
     }
 
-    clearTimeout(this.timer);
-    this.timer = null;
+    clearInterval(this.protocolRateTimer);
+    this.protocolRateTimer = null;
+
+    clearTimeout(this.protocolPeriodTimer);
+    this.protocolPeriodTimer = null;
+
     this.isStopped = true;
 
     this.ringpop.logger.debug('stopped gossip protocol', {

--- a/test/swim_test.js
+++ b/test/swim_test.js
@@ -64,24 +64,26 @@ test('join is aborted when max join duration is exceeded', function t(assert) {
     assert.end();
 });
 
-test('starting and stopping gossip sets timer / unsets timer', function t(assert) {
+test('starting and stopping gossip sets timer / unsets timers', function t(assert) {
     var gossip = createGossip();
 
     gossip.start();
-    assert.ok(gossip.timer, 'timer was set');
+    assert.ok(gossip.protocolPeriodTimer, 'protocol period timer was set');
+    assert.ok(gossip.protocolRateTimer, 'protocol rate timer was set');
 
     gossip.stop();
-    assert.notok(gossip.timer, 'timer was cleared');
+    assert.notok(gossip.protocolPeriodTimer, 'protocol period timer was cleared');
+    assert.notok(gossip.protocolRateTimer, 'protocol rate timer was cleared');
 
     assert.end();
 });
 
 test('stopping gossip is a noop if gossip was never started', function t(assert) {
     var gossip = createGossip();
-    gossip.timer = 'nochange';
+    gossip.protocolPeriodTimer = 'nochange';
 
     gossip.stop();
-    assert.equals(gossip.timer, 'nochange', 'timer was not cleared');
+    assert.equals(gossip.protocolPeriodTimer, 'nochange', 'timer was not cleared');
     assert.equals(gossip.isStopped, true, 'gossip was not stopped');
 
     assert.end();
@@ -92,11 +94,11 @@ test('gossip can be restarted', function t(assert) {
     gossip.start();
 
     gossip.stop();
-    assert.equals(gossip.timer, null, 'timer was cleared');
+    assert.equals(gossip.protocolPeriodTimer, null, 'timer was cleared');
     assert.equals(gossip.isStopped, true, 'gossip was stopped');
 
     gossip.start();
-    assert.ok(gossip.timer, 'timer was set');
+    assert.ok(gossip.protocolPeriodTimer, 'timer was set');
     assert.equals(gossip.isStopped, false, 'gossip was started');
 
     gossip.stop(); // Cleanup


### PR DESCRIPTION
...ter every ping

This was effectively a one-line change that has been broken since the move over to tchannel. This bug caused the protocol period to be around 400ms stable-state instead of 200ms. The reason is because the `timing` metric wasn't updated after ping responses were received. This was subtle logic baked into the HTTP transport. I need to harden this against future issues. But I'm punting on that for now.

I took this opportunity to clean some code out of `index.js` and move it into `Gossip`. I think this separates concerns better. Everything having to do with the gossip protocol period is managed by the Gossip abstraction.

The one-line fix is literally the line that now reads: `this.protocolTiming.update(new Date() - pingStartTime);`

@Raynos @mranney 