### PR TITLE
Request proxy retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,11 @@ function RingPop(options) {
     this.membershipUpdateFlushInterval = options.membershipUpdateFlushInterval ||
         MEMBERSHIP_UPDATE_FLUSH_INTERVAL;
 
-    this.requestProxy = new RequestProxy(this);
+    this.requestProxy = new RequestProxy({
+        ringpop: this,
+        maxRetries: options.requestProxyMaxRetries,
+        retrySchedule: options.requestProxyRetrySchedule
+    });
     this.ring = new HashRing();
     this.dissemination = new Dissemination(this);
     this.membership = new Membership(this);
@@ -129,6 +133,7 @@ RingPop.prototype.destroy = function destroy() {
     this.gossip.stop();
     this.suspicion.stopAll();
     this.membershipUpdateRollup.destroy();
+    this.requestProxy.destroy();
 
     this.clientRate.m1Rate.stop();
     this.clientRate.m5Rate.stop();

--- a/lib/request-proxy.js
+++ b/lib/request-proxy.js
@@ -26,6 +26,8 @@ var TypedError = require('error/typed');
 
 var safeParse = require('./util').safeParse;
 
+var RETRY_SCHEDULE = [0, 1, 3.5];
+
 var InvalidCheckSumError = TypedError({
     type: 'ringpop.request-proxy.invalid-checksum',
     message: 'Expected the remote checksum to match local ' +
@@ -36,19 +38,55 @@ var InvalidCheckSumError = TypedError({
     expected: null
 });
 
+var MaxRetriesExceeded = TypedError({
+    type: 'ringpop.request-proxy.max-retries-exceeded',
+    message: 'Max number of retries ({maxRetries}) to fulfill request have been exceeded',
+    maxRetries: null
+});
+
 module.exports = RequestProxy;
 
-function RequestProxy(ringpop) {
-    this.ringpop = ringpop;
+function numOrDefault(num, def) {
+    return typeof num === 'number' ? num : def;
+}
+
+function RequestProxy(opts) {
+    this.ringpop = opts.ringpop;
+    this.retrySchedule = opts.retrySchedule || RETRY_SCHEDULE;
+    this.maxRetries = numOrDefault(opts.maxRetries, this.retrySchedule.length);
+
+    // Simply a convenience over having to index into `retrySchedule` each time
+    this.maxRetryTimeout = this.retrySchedule[this.retrySchedule.length - 1];
+
+    this.retryTimeouts = [];
 }
 
 var proto = RequestProxy.prototype;
 
+proto.clearRetryTimeout = function clearRetryTimeout(timeout) {
+    var indexOf = this.retryTimeouts.indexOf(timeout);
+
+    if (indexOf !== -1) {
+        this.retryTimeouts.splice(indexOf, 1);
+    }
+};
+
+proto.destroy = function destroy() {
+    this.retryTimeouts.forEach(function eachTimeout(timeout) {
+        clearTimeout(timeout);
+    });
+
+    this.retryTimeouts = [];
+};
+
 proto.proxyReq = function proxyReq(opts) {
+    var self = this;
     var keys = opts.keys;
     var dest = opts.dest;
     var req = opts.req;
     var res = opts.res;
+    var maxRetries = opts.maxRetries;
+    var retrySchedule = opts.retrySchedule;
 
     var ringpop = this.ringpop;
     var url = req.url;
@@ -86,8 +124,9 @@ proto.proxyReq = function proxyReq(opts) {
         ringpop.logger.trace('requestProxy sending tchannel proxy req', {
             url: req.url
         });
-        ringpop.channel.send(options, '/proxy/req',
-            head, rawBody, onProxy);
+
+        var sendIt = sendHandler();
+        sendIt(options, head, rawBody, onProxy);
     }
 
     function onProxy(err, res1, res2) {
@@ -122,6 +161,93 @@ proto.proxyReq = function proxyReq(opts) {
         });
         res.end(res2);
     }
+
+    function sendHandler() {
+        // Per-request parameters override instance-level
+        maxRetries = numOrDefault(maxRetries, self.maxRetries);
+        retrySchedule = retrySchedule || self.retrySchedule;
+
+        var numRetries = 0;
+        var reqStartTime = Date.now();
+        var retryStartTime = null;
+
+        return function sendIt(options, head, body, callback) {
+            if (maxRetries === 0) {
+                ringpop.channel.send(options, '/proxy/req',
+                    head, body, callback);
+                return;
+            }
+
+            ringpop.channel.send(options, '/proxy/req', head, body, onSend);
+
+            function onSend(err, res1, res2) {
+                if (!err) {
+                    if (numRetries > 0) {
+                        ringpop.stat('increment', 'requestProxy.retry.succeeded');
+                        ringpop.logger.info('ringpop request proxy retry succeeded', {
+                            numRetries: numRetries,
+                            maxRetries: maxRetries,
+                            reqMethod: req.method,
+                            reqUrl: req.url,
+                            reqStartTime: reqStartTime,
+                            reqTotalTime: Date.now() - reqStartTime,
+                            retrySchedule: retrySchedule,
+                            retryStartTime: retryStartTime,
+                            retryTotalTime: Date.now() - retryStartTime
+                        });
+                        ringpop.emit('requestProxy.retrySucceeded');
+                    }
+
+                    callback(null, res1, res2);
+                    return;
+                }
+
+                if (numRetries >= maxRetries) {
+                    ringpop.stat('increment', 'requestProxy.retry.failed');
+                    ringpop.logger.warn('ringpop request proxy retry exceeded max retries and failed', {
+                        maxRetries: maxRetries,
+                        maxRetryTimeout: self.maxRetryTimeout,
+                        reqMethod: req.method,
+                        reqUrl: req.url,
+                        reqStartTime: reqStartTime,
+                        reqTotalTime: Date.now() - reqStartTime,
+                        retrySchedule: retrySchedule,
+                        retryStartTime: retryStartTime,
+                        retryTotalTime: Date.now() - retryStartTime
+                    });
+                    ringpop.emit('requestProxy.retryFailed');
+
+                    callback(MaxRetriesExceeded({
+                        maxRetries: maxRetries
+                    }));
+                    return;
+                } else {
+                    if (numRetries === 0) {
+                        retryStartTime = Date.now();
+                    }
+
+                    // TODO Can we make this timeout value responsive/adaptive to previously
+                    // recorded cluster converge-times?
+                    var delay = numOrDefault(retrySchedule[numRetries] * 1000,
+                        self.maxRetryTimeout);
+                    var timeout = setTimeout(function onTimeout() {
+                        numRetries++;
+
+                        self.clearRetryTimeout(timeout);
+
+                        sendIt(options, head, body, callback);
+
+                        ringpop.stat('increment', 'requestProxy.retry.attempted');
+                        ringpop.emit('requestProxy.retryAttempted');
+                    }, delay);
+
+                    self.retryTimeouts.push(timeout);
+
+                    ringpop.emit('requestProxy.retryScheduled');
+                }
+            }
+        };
+    }
 };
 
 proto.handleRequest = function handleRequest(head, body, cb) {
@@ -141,6 +267,7 @@ proto.handleRequest = function handleRequest(head, body, cb) {
             err: err,
             url: url
         });
+        ringpop.emit('requestProxy.checksumsDiffer');
         return cb(err);
     }
 

--- a/test/integration/proxy_req_test.js
+++ b/test/integration/proxy_req_test.js
@@ -19,9 +19,12 @@
 // THE SOFTWARE.
 'use strict';
 
+var after = require('after');
 var test = require('tape');
 
 var allocCluster = require('../lib/alloc-cluster.js');
+
+var retrySchedule = [0, 0.01, 0.02];
 
 test('can proxyReq() to someone', function t(assert) {
     var cluster = allocCluster(function onReady() {
@@ -42,6 +45,244 @@ test('can proxyReq() to someone', function t(assert) {
             assert.equal(resp.body.payload.hello, true);
 
             cluster.destroy();
+            assert.end();
+        });
+    });
+});
+
+test('one retry', function t(assert) {
+    assert.plan(6);
+
+    var ringpopOpts = {
+        requestProxyMaxRetries: 3,
+        requestProxyRetrySchedule: retrySchedule
+    };
+
+    var cluster = allocCluster(ringpopOpts, function onReady() {
+        cluster.two.membership.checksum = cluster.one.membership.checksum + 1;
+
+        cluster.two.once('requestProxy.checksumsDiffer', function onBadChecksum() {
+            assert.pass('received request with invalid checksum');
+            cluster.two.membership.checksum = cluster.one.membership.checksum;
+        });
+
+        cluster.two.once('request', function onGoodChecksum() {
+            assert.pass('received subsequent request with valid checksum');
+        });
+
+        cluster.request({
+            key: cluster.keys.two,
+            host: 'one',
+            json: { hello: true }
+        }, function onResponse(err, resp) {
+            assert.ifErr(err);
+
+            assert.equal(resp.statusCode, 200);
+            assert.equal(resp.body.host, 'two');
+            assert.equal(resp.body.payload.hello, true);
+
+            cluster.destroy();
+            assert.end();
+        });
+    });
+});
+
+test('two retries', function t(assert) {
+    assert.plan(9);
+
+    var ringpopOpts = {
+        requestProxyMaxRetries: 3,
+        requestProxyRetrySchedule: retrySchedule
+    };
+    var numAttempts = 0;
+
+    var cluster = allocCluster(ringpopOpts, function onReady() {
+        cluster.two.membership.checksum = cluster.one.membership.checksum + 1;
+
+        cluster.two.on('requestProxy.checksumsDiffer', function onBadChecksum() {
+            numAttempts++;
+
+            // If last retry
+            if (numAttempts === cluster.two.requestProxy.maxRetries) {
+                cluster.two.membership.checksum = cluster.one.membership.checksum;
+            }
+
+            assert.pass('received request with invalid checksum');
+        });
+
+        cluster.two.once('request', function onGoodChecksum() {
+            numAttempts++;
+            assert.pass('received request with valid checksum on last retry');
+        });
+
+        cluster.request({
+            key: cluster.keys.two,
+            host: 'one',
+            json: { hello: true }
+        }, function onResponse(err, resp) {
+            assert.ifErr(err);
+
+            assert.equal(resp.statusCode, 200);
+            assert.equal(resp.body.host, 'two');
+            assert.equal(resp.body.payload.hello, true);
+
+            assert.equal(numAttempts, cluster.two.requestProxy.maxRetries + 1);
+
+            cluster.destroy();
+            assert.end();
+        });
+    });
+});
+
+test('no retries, invalid checksum', function t(assert) {
+    assert.plan(4);
+
+    var numAttempts = 0;
+    var ringpopOpts = {
+        requestProxyMaxRetries: 0
+    };
+
+    var cluster = allocCluster(ringpopOpts, function onReady() {
+        cluster.two.membership.checksum = cluster.one.membership.checksum + 1;
+
+        cluster.two.on('requestProxy.checksumsDiffer', function onBadChecksum() {
+            numAttempts++;
+            assert.pass('received request with invalid checksum');
+        });
+
+        cluster.two.once('request', function onGoodChecksum() {
+            numAttempts++;
+            assert.fail('never emits a request event');
+        });
+
+        cluster.request({
+            key: cluster.keys.two,
+            host: 'one',
+            json: { hello: true }
+        }, function onResponse(err, resp) {
+            assert.ifErr(err);
+
+            assert.equal(resp.statusCode, 500);
+            assert.equal(numAttempts, 1, 'only 1 attempt because no retries');
+
+            cluster.destroy();
+            assert.end();
+        });
+    });
+});
+
+test('exceeds max retries, errors out', function t(assert) {
+    assert.plan(9);
+
+    var numAttempts = 0;
+    var ringpopOpts = {
+        requestProxyMaxRetries: 5,
+        requestProxyRetrySchedule: retrySchedule
+    };
+
+    var cluster = allocCluster(ringpopOpts, function onReady() {
+        cluster.two.membership.checksum = cluster.one.membership.checksum + 1;
+
+        cluster.two.on('requestProxy.checksumsDiffer', function onBadChecksum() {
+            numAttempts++;
+            assert.pass('received request with invalid checksum');
+        });
+
+        cluster.two.once('request', function onGoodChecksum() {
+            numAttempts++;
+            assert.fail('never emits a request event');
+        });
+
+        cluster.request({
+            key: cluster.keys.two,
+            host: 'one',
+            json: { hello: true }
+        }, function onResponse(err, resp) {
+            assert.ifErr(err);
+
+            assert.equal(resp.statusCode, 500);
+            assert.equal(numAttempts, ringpopOpts.requestProxyMaxRetries + 1, '1 initial send + maxRetries');
+
+            cluster.destroy();
+            assert.end();
+        });
+    });
+});
+
+test('removes timeout timers', function t(assert) {
+    var numRequests = 3;
+
+    var done = after(numRequests, function onDone() {
+        var beforeDestroy = cluster.one.requestProxy.retryTimeouts.length;
+        assert.equal(beforeDestroy, numRequests, 'timers are pending');
+
+        cluster.destroy();
+
+        var afterDestroy = cluster.one.requestProxy.retryTimeouts.length;
+        assert.equal(afterDestroy, 0, 'timers are cleared');
+
+        assert.end();
+    });
+
+    var ringpopOpts = {
+        // Really really long delays before retry is initiated
+        requestProxyRetrySchedule: [100000, 200000, 300000]
+    };
+
+    var cluster = allocCluster(ringpopOpts, function onReady() {
+        cluster.two.membership.checksum = cluster.one.membership.checksum + 1;
+
+        cluster.one.on('requestProxy.retryScheduled', function onRetry() {
+            done();
+        });
+
+        function onRequest() {
+            assert.fail('no response');
+        }
+
+        for (var i = 0; i < numRequests; i++) {
+            cluster.request({
+                key: cluster.keys.two,
+                host: 'one',
+                json: { hello: true }
+            }, onRequest);
+        }
+    });
+});
+
+test('removes some timeouts, not others', function t(assert) {
+    var ringpopOpts = {
+        // Really really long delays before retry is initiated
+        requestProxyRetrySchedule: [100000, 200000, 300000]
+    };
+
+    var cluster = allocCluster(ringpopOpts, function onReady() {
+        cluster.two.membership.checksum = cluster.one.membership.checksum + 1;
+
+        // Only one retry will be attempted, others will still be waiting
+        cluster.one.on('requestProxy.retryAttempted', function onRetry() {
+            cluster.two.membership.checksum = cluster.one.membership.checksum;
+        });
+
+        for (var i = 0; i < 2; i++) {
+            cluster.request({
+                key: cluster.keys.two,
+                host: 'one',
+                json: { hello: true }
+            }, assert.fail);
+        }
+
+        cluster.request({
+            key: cluster.keys.two,
+            host: 'one',
+            json: { hello: true },
+            retrySchedule: [0]
+        }, function onRequest() {
+            var beforeDestroy = cluster.one.requestProxy.retryTimeouts.length;
+            assert.equal(beforeDestroy, 2, 'timers are pending');
+
+            cluster.destroy();
+
             assert.end();
         });
     });

--- a/test/integration/request_proxy_test.js
+++ b/test/integration/request_proxy_test.js
@@ -97,7 +97,8 @@ test('will timeout after default timeout', function t(assert) {
             return function handle() {
                 // do nothing to timeout
             };
-        }
+        },
+        requestProxyMaxRetries: 0
     }, function onReady() {
         cluster.request({
             host: 'one', key: cluster.keys.two,
@@ -221,7 +222,8 @@ test('custom timeouts', function t(assert) {
             return function handle() {
                 // do nothing to timeout
             };
-        }
+        },
+        requestProxyMaxRetries: 0
     }, function onReady() {
         cluster.request({
             host: 'one', key: cluster.keys.two,
@@ -294,7 +296,8 @@ test('handle tchannel failures', function t(assert) {
             return function handle() {
                 // do nothing to timeout
             };
-        }
+        },
+        requestProxyMaxRetries: 0
     }, function onReady() {
         cluster.request({
             host: 'one', key: cluster.keys.two
@@ -318,7 +321,11 @@ test('handle tchannel failures', function t(assert) {
 });
 
 test('handles checksum failures', function t(assert) {
-    var cluster = allocCluster(function onReady() {
+    var ringpopOpts = {
+        requestProxyMaxRetries: 0
+    };
+
+    var cluster = allocCluster(ringpopOpts, function onReady() {
         cluster.two.membership.addMember({
             address: 'localhost:9999',
             status: 'fake',

--- a/test/lib/alloc-cluster.js
+++ b/test/lib/alloc-cluster.js
@@ -84,7 +84,8 @@ function allocCluster(options, onReady) {
         var host = opts.host;
 
         var handle = cluster[host].handleOrProxy(key, req, res, {
-            timeout: opts.timeout
+            timeout: opts.timeout,
+            retrySchedule: opts.retrySchedule
         });
         if (handle) {
             cluster[host].emit('request', req, res);

--- a/test/lib/alloc-ringpop.js
+++ b/test/lib/alloc-ringpop.js
@@ -43,7 +43,9 @@ function allocRingpop(name, options) {
         app: 'test.ringpop.proxy_req_test',
         hostPort: hostPort,
         logger: DebuglogLogger('proxy_req_test: ' + name),
-        channel: tchannel
+        channel: tchannel,
+        requestProxyMaxRetries: options && options.requestProxyMaxRetries,
+        requestProxyRetrySchedule: options && options.requestProxyRetrySchedule
     });
 
     ringpop.setupChannel();

--- a/test/mock/request-proxy.js
+++ b/test/mock/request-proxy.js
@@ -22,5 +22,6 @@
 var noop = require('./noop.js');
 
 module.exports = {
+    destroy: noop,
     proxyReq: noop
 };

--- a/test/request_proxy_test.js
+++ b/test/request_proxy_test.js
@@ -32,7 +32,9 @@ function createRingpop() {
 }
 
 function createRequestProxy() {
-    return new RequestProxy(createRingpop());
+    return new RequestProxy({
+        ringpop: createRingpop()
+    });
 }
 
 test('request proxy sends custom ringpop metadata in head', function t(assert) {


### PR DESCRIPTION
Proxied requests suffer from cluster inconsistencies on deploys and what not. Build retries w/ backoff into the request proxying layer to deal with an eventually convergent ring. @Raynos recommended I use a module for backoff, but I decided against it due to the simplicity of the approach below. Feel free to feedback.

@Raynos @jmccarthy14 @mranney @jsu1212 @jcorbin 