### PR TITLE
Split changed event into two: membershipChanged and ringChanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ All other properties should be considered private. Any mutation of properties no
 ## Events
 
 * `ready` - Ringpop is ready
-* `changed` - Ring state has changed
+* `changed` - Ring state has changed (DEPRECATED)
+* `membershipChanged` - Membership state has changed for one or more members, either their status or incarnation number. A membership change may result in a ring change.
+* `ringChanged` - Ring state has changed for one or more nodes: a node has been added to or removed from the cluster. All ring changes are also member changes, but not vice versa.
 
 ## Installation
 

--- a/lib/members.js
+++ b/lib/members.js
@@ -338,19 +338,23 @@ Membership.prototype.hasMember = function hasMember(member) {
     return !!this.findMemberByAddress(member.address);
 };
 
-Membership.prototype.makeAlive = function makeAlive(address) {
+// Alive operation requires only an address. Incarnation number can be
+// passed optionally, but nodes should never bump the incarnation number
+// of a remote member. Incarnation number, for now, is only available
+// for ease of testing.
+Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
     var member = this.findMemberByAddress(address);
 
     if (member) {
         this.update([{
             address: member.address,
-            incarnationNumber: member.incarnationNumber,
+            incarnationNumber: incarnationNumber || member.incarnationNumber,
             status: 'alive'
         }]);
     }
 };
 
-Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
+Membership.prototype.makeFaulty = function makeFaulty(address) {
     var member = this.findMemberByAddress(address);
 
     if (member) {
@@ -362,6 +366,20 @@ Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber
     }
 };
 
+// Join operation requires both an address and initial incarnation number
+Membership.prototype.makeJoin = function makeJoin(address, incarnationNumber) {
+    if (!address || !incarnationNumber) {
+        return;
+    }
+
+    this.update([{
+        address: address,
+        status: 'alive',
+        incarnationNumber: incarnationNumber
+    }]);
+};
+
+// Leave operations are only allowed on the local member
 Membership.prototype.makeLeave = function makeLeave() {
     this.update([{
         address: this.localMember.address,
@@ -370,6 +388,7 @@ Membership.prototype.makeLeave = function makeLeave() {
     }]);
 };
 
+// Suspect operation requires no change of the incarnation number
 Membership.prototype.makeSuspect = function makeSuspect(address) {
     var member = this.findMemberByAddress(address);
 


### PR DESCRIPTION
This change is necessary for the sevnups of the world that are looking to take action when ring-state changes (node added/removed). The problem today is that ringpop will fire events for both membership changes and ring changes under the same name causing sevnup to rescan the vnode-space for membership updates like when node are suspected. This is not a huge problem, but splitting events improves correctness.

@iproctor @Raynos @jmccarthy14 