### PR TITLE
Stringify our bodies and responses for tchannel.

### DIFF
--- a/lib/swim.js
+++ b/lib/swim.js
@@ -85,11 +85,11 @@ AdminJoiner.prototype.sendJoin = function sendJoin() {
         timeout: this.ringpop.pingReqTimeout
     };
     var local = this.ringpop.membership.localMember;
-    var body = {
+    var body = JSON.stringify({
         app: this.ringpop.app,
         source: local.address,
         incarnationNumber: local.incarnationNumber
-    };
+    });
     var self = this;
     this.ringpop.channel.send(options, '/protocol/join', null, body, function (err, res1, res2) {
         self.onJoin(err, res1, res2);
@@ -185,12 +185,12 @@ function PingReqSender(ring, member, target, callback) {
         host: member.address,
         timeout: this.ring.pingReqTimeout
     };
-    var body = {
+    var body = JSON.stringify({
         checksum: this.checksum,
         changes: this.ring.issueMembershipChanges(),
         source: this.ring.whoami(),
         target: target.address
-    };
+    });
 
     var self = this;
     this.ring.channel.send(options, '/protocol/ping-req', null, body, function(err, res1, res2) {
@@ -225,11 +225,11 @@ function PingSender(ring, member, callback) {
         timeout: ring.pingTimeout
     };
     var changes = ring.issueMembershipChanges();
-    var body = {
+    var body = JSON.stringify({
         checksum: ring.membership.checksum,
         changes: changes,
         source: ring.whoami()
-    };
+    });
 
     this.ring.debugLog('ping send member=' + this.address + ' changes=' + JSON.stringify(changes), 'p');
 

--- a/lib/tchannel.js
+++ b/lib/tchannel.js
@@ -62,7 +62,7 @@ RingPopTChannel.prototype.health = function (arg1, arg2, hostInfo, cb) {
 };
 
 RingPopTChannel.prototype.adminStats = function (arg1, arg2, hostInfo, cb) {
-    cb(null, null, this.ringPop.getStats());
+    cb(null, null, JSON.stringify(this.ringPop.getStats()));
 };
 
 RingPopTChannel.prototype.adminDebugSet = function (arg1, arg2, hostInfo, cb) {
@@ -94,7 +94,9 @@ RingPopTChannel.prototype.adminJoin = function (arg1, arg2, hostInfo, cb) {
             if (err) {
                 return cb(err);
             }
-            cb(null, { candidateHosts: candidateHosts });
+            cb(null, JSON.stringify({
+                candidateHosts: candidateHosts
+            }));
         });
     } else {
         cb(new Error('bad JSON in request'));
@@ -112,7 +114,7 @@ RingPopTChannel.prototype.adminReload = function (arg1, arg2, hostInfo, cb) {
 
 RingPopTChannel.prototype.adminTick = function (arg1, arg2, hostInfo, cb) {
     this.ringPop.handleTick(function onTick(err, resp) {
-        cb(err, null, resp);
+        cb(err, null, JSON.stringify(resp));
     });
 };
 
@@ -134,7 +136,7 @@ RingPopTChannel.prototype.protocolJoin = function (arg1, arg2, hostInfo, cb) {
         source: source,
         incarnationNumber: incarnationNumber
     }, function(err, res) {
-        cb(err, null, res);
+        cb(err, null, JSON.stringify(res));
     });
 };
 
@@ -152,7 +154,9 @@ RingPopTChannel.prototype.protocolLeave = function (arg1, arg2, hostInfo, cb) {
     // that handled leave request, aka this node. This will
     // not be obvious to the requester as the leave could
     // happen through haproxy.
-    cb(null, null, { coordinator: this.ringPop.whoami() });
+    cb(null, null, JSON.stringify({
+        coordinator: this.ringPop.whoami()
+    }));
 };
 
 RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
@@ -166,7 +170,7 @@ RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
         changes: body.changes,
         checksum: body.checksum
     }, function(err, res) {
-        cb(err, null, res);
+        cb(err, null, JSON.stringify(res));
     });
 };
 
@@ -182,7 +186,7 @@ RingPopTChannel.prototype.protocolPingReq = function (arg1, arg2, hostInfo, cb) 
         changes: body.changes,
         checksum: body.checksum
     }, function(err, result) {
-        cb(err, null, result);
+        cb(err, null, JSON.stringify(result));
     });
 };
 


### PR DESCRIPTION
Tchannel v1 expects to get an object, string or buffer.

Tchannel v2 expects a string or buffer.

If you pass an object to tchannel v1 it will stringify it
for you. We should stringify it explicitely in ringpop so
that ringpop works with either v1 or v2.

reviewers: @jwolski @jcorbin

cc: @jsu1212