### PR TITLE
fix: don't ignore --hosts command line argument value

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,7 +86,7 @@ function main() {
     });
 
     createRingPopTChannel(ringpop, tchannel);
-    ringpop.bootstrap();
+    ringpop.bootstrap(program.hosts);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
The --hosts argument is required, but its value is then ignored. It probably works out most of the time, since the default value of ./hosts.json is there. Still, a bug.

Tested with a seed hosts file value of "hosts1.json". Before fix, main barfs looking for "./hosts.json". 

Works as expected after fix.

Unit tests pass (as per git hooks)