### PR TITLE
Introduce lower bound on incarnation number for local member asserting its aliveness

### DIFF
--- a/lib/member.js
+++ b/lib/member.js
@@ -17,4 +17,17 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-require('glob').sync(__dirname + '/**/*{_test,-test}.js').forEach(require);
+'use strict';
+
+function Member() {
+
+}
+
+Member.Status = {
+    Alive: 'alive',
+    Faulty: 'faulty',
+    Leave: 'leave',
+    Suspect: 'suspect'
+};
+
+module.exports = Member;

--- a/lib/members.js
+++ b/lib/members.js
@@ -18,8 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 var _ = require('underscore');
-var farmhash = require('farmhash');
 var EventEmitter = require('events').EventEmitter;
+var farmhash = require('farmhash');
+var Member = require('./member.js');
 var util = require('util');
 
 var LOG_10 = Math.log(10);
@@ -192,11 +193,15 @@ Membership.isLeaveOverride = function isLeaveOverride(member, change) {
 };
 
 Membership.isLocalFaultyOverride = function isLocalFaultyOverride(member, change) {
-    return member.isLocal && change.status === 'faulty';
+    return member.isLocal &&
+        change.status === Member.Status.Faulty &&
+        change.incarnationNumber >= member.incarnationNumber;
 };
 
 Membership.isLocalSuspectOverride = function isLocalSuspectOverride(member, change) {
-    return member.isLocal && change.status === 'suspect';
+    return member.isLocal &&
+        change.status === Member.Status.Suspect &&
+        change.incarnationNumber >= member.incarnationNumber;
 };
 
 Membership.isSuspectOverride = function isSuspectOverride(member, change) {

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -17,4 +17,35 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-require('glob').sync(__dirname + '/**/*{_test,-test}.js').forEach(require);
+'use strict';
+
+var Ringpop = require('../../index.js');
+var tape = require('tape');
+
+function testRingpop(opts, name, test) {
+    if (typeof opts === 'string' && typeof name === 'function') {
+        test = name;
+        name = opts;
+        opts = {};
+    }
+
+    tape(name, function onTest(assert) {
+        var ringpop = new Ringpop({
+            app: opts.app || 'test',
+            hostPort: opts.hostPort || '127.0.0.1:3000'
+        });
+
+        ringpop.addLocalMember();
+
+        test({
+            localMember: ringpop.membership.localMember,
+            membership: ringpop.membership,
+            ringpop: ringpop
+        }, assert);
+
+        assert.end();
+        ringpop.destroy();
+    });
+}
+
+module.exports = testRingpop;

--- a/test/local-incarnation-test.js
+++ b/test/local-incarnation-test.js
@@ -17,4 +17,33 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-require('glob').sync(__dirname + '/**/*{_test,-test}.js').forEach(require);
+'use strict';
+
+// Test dependencies
+var Member = require('../lib/member.js');
+
+// Test helpers
+var testRingpop = require('./lib/test-ringpop.js');
+
+function assertIncarnationNumber(deps, assert, memberStatus) {
+    var membership = deps.membership;
+    var local = membership.localMember;
+    var prevInc = local.incarnationNumber;
+
+    membership.update([{
+        address: local.address,
+        status: memberStatus
+    }]);
+
+    assert.ok(prevInc, 'prev incarnation number is truthy');
+    assert.equal(local.incarnationNumber, prevInc,
+        'incarnation number is unchanged');
+}
+
+testRingpop('suspect update does not bump local incarnation number', function t(deps, assert) {
+    assertIncarnationNumber(deps, assert, Member.Status.Suspect);
+});
+
+testRingpop('faulty update does not bump local incarnation number', function t(deps, assert) {
+    assertIncarnationNumber(deps, assert, Member.Status.Faulty);
+});


### PR DESCRIPTION
Without having a lower bound on the incarnation number, it causes cluster to disseminate more changes than necessary. During a deploy, nodes that detect suspects are disseminating that info throughout the cluster eventually arriving at the original suspect once restarted. When applying the change at that member, incarnation number is bumped a bunch of times until the ring converges. This is apparent in the membership update rollups recently introduced:

```
fields.updates_.10.30.11.2:20801_	  	{"type":"suspect","address":"10.30.11.2:20801","status":"suspect","incarnationNumber":1424847893496,"isLocal":false}, {"type":"alive","address":"10.30.11.2:20801","status":"alive","incarnationNumber":1425346015439,"isLocal":false}, {"type":"alive","address":"10.30.11.2:20801","status":"alive","incarnationNumber":1425346015737,"isLocal":false}, {"type":"alive","address":"10.30.11.2:20801","status":"alive","incarnationNumber":1425346016474,"isLocal":false}
```

Notice:
statuses: suspect -> alive -> alive -> alive -> alive

incarnation numbers: 
1424847893496
1425346015439
1425346015737
1425346016474

@iproctor @Raynos @mrhooray 