### PR TITLE
Send over checksum with /protocol/ping-req

### DIFF
--- a/lib/swim.js
+++ b/lib/swim.js
@@ -33,7 +33,7 @@ function PingReqSender(ring, member, target, callback) {
         timeout: this.ring.pingReqTimeout
     };
     var body = JSON.stringify({
-        checksum: this.checksum,
+        checksum: this.ring.membership.checksum,
         changes: this.ring.issueMembershipChanges(),
         source: this.ring.whoami(),
         target: target.address


### PR DESCRIPTION
In preparation for flap damping, I need to fix how ping-req's are currently handled. Amidst that minor rewrite, I stumbled upon this lovely bug. `checksum` was never passed to /protocol/ping-req even though it's a required field. What would happen is that for any ping that would fail, the member would be immediately deemed a suspect regardless of whether the chosen ping-req members could reach the node or not. This usually wasn't spotted because when most pings fail, the member is indeed being restarted or crashed or otherwise. For those transient ping failures, this bug would cause unintended membership changes, from suspect then quickly back to alive.

This could have easily been caught by integration tests. And, good news, they are coming with the aforementioned minor ping-req rewrite. But not in this PR. I'm treating this as a hotfix.

@Raynos @leizha @robskillington 