### PR TITLE
Always pass head object when emitting 'request' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ var PingReqSender = require('./lib/swim').PingReqSender;
 var PingSender = require('./lib/swim').PingSender;
 var safeParse = require('./lib/util').safeParse;
 var RequestProxy = require('./lib/request-proxy');
-var serializeHead = require('./lib/request-proxy-util.js').serializeHead;
+var rawHead = require('./lib/request-proxy-util.js').rawHead;
 var Suspicion = require('./lib/swim.js').Suspicion;
 
 var HOST_PORT_PATTERN = /^(\d+.\d+.\d+.\d+):\d+$/;
@@ -860,7 +860,7 @@ RingPop.prototype.handleOrProxyAll =
                     url: req && req.url,
                     dest: dest
                 });
-                var head = serializeHead(req, {
+                var head = rawHead(req, {
                     checksum: self.membership.checksum,
                     keys: destKeys
                 });

--- a/lib/request-proxy-util.js
+++ b/lib/request-proxy-util.js
@@ -19,17 +19,22 @@
 // THE SOFTWARE.
 'use strict';
 
-function serializeHead(req, ringpopOpts) {
-    return JSON.stringify({
+function rawHead(req, ringpopOpts) {
+    return {
         url: req.url,
         headers: req.headers,
         method: req.method,
         httpVersion: req.httpVersion,
         ringpopChecksum: ringpopOpts.checksum,
         ringpopKeys: ringpopOpts.keys
-    });
+    };
+}
+
+function strHead(req, ringpopOpts) {
+    return JSON.stringify(rawHead(req, ringpopOpts));
 }
 
 module.exports = {
-    serializeHead: serializeHead
+    rawHead: rawHead,
+    strHead: strHead
 };

--- a/lib/request-proxy.js
+++ b/lib/request-proxy.js
@@ -25,7 +25,7 @@ var hammock = require('uber-hammock');
 var TypedError = require('error/typed');
 
 var safeParse = require('./util').safeParse;
-var serializeHead = require('./request-proxy-util.js').serializeHead;
+var strHead = require('./request-proxy-util.js').strHead;
 
 var RETRY_SCHEDULE = [0, 1, 3.5];
 
@@ -110,7 +110,7 @@ proto.proxyReq = function proxyReq(opts) {
             host: dest,
             timeout: timeout
         };
-        var head = serializeHead(req, {
+        var head = strHead(req, {
             checksum: ringpop.membership.checksum,
             keys: keys
         });

--- a/test/integration/proxy_req_test.js
+++ b/test/integration/proxy_req_test.js
@@ -23,7 +23,7 @@ var after = require('after');
 var test = require('tape');
 
 var allocCluster = require('../lib/alloc-cluster.js');
-var serializeHead = require('../../lib/request-proxy-util.js').serializeHead;
+var strHead = require('../../lib/request-proxy-util.js').strHead;
 
 var retrySchedule = [0, 0.01, 0.02];
 
@@ -324,7 +324,7 @@ test('overrides /proxy/req endpoint', function t(assert) {
             assert.end();
         });
 
-        var head = serializeHead(request, {
+        var head = strHead(request, {
             checksum: cluster.two.membership.checksum,
             keys: [cluster.keys.two]
         });


### PR DESCRIPTION
@jwolski @Raynos 

This is done so that when a request is handled locally, the downstream handler is able to see and use the keys.

I could also duplicate the keys in both headers in order to avoid a breaking change, if we think that's better.