### PR TITLE
Ping-req uses only ping status from unreachable member to initiate suspect period

### DIFF
--- a/lib/swim/ping-req-recvr.js
+++ b/lib/swim/ping-req-recvr.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+module.exports = function recvPingReq(opts, callback) {
+    var ringpop = opts.ringpop;
+
+    ringpop.stat('increment', 'ping-req.recv');
+
+    var source = opts.source;
+    var target = opts.target;
+    var changes = opts.changes;
+    var checksum = opts.checksum;
+
+    ringpop.serverRate.mark();
+    ringpop.totalRate.mark();
+    ringpop.membership.update(changes);
+
+    ringpop.debugLog('ping-req send ping source=' + source + ' target=' + target, 'p');
+
+    var start = new Date();
+    ringpop.sendPing(target, function (isOk, body) {
+        ringpop.stat('timing', 'ping-req-ping', start);
+        ringpop.debugLog('ping-req recv ping source=' + source + ' target=' + target + ' isOk=' + isOk, 'p');
+
+        if (isOk) {
+            ringpop.membership.update(body.changes);
+        }
+
+        callback(null, {
+            changes: ringpop.issueMembershipChanges(checksum, source),
+            pingStatus: isOk,
+            target: target
+        });
+    });
+};

--- a/lib/swim/ping-req-sender.js
+++ b/lib/swim/ping-req-sender.js
@@ -19,45 +19,249 @@
 // THE SOFTWARE.
 'use strict';
 var safeParse = require('../util').safeParse;
+var TypedError = require('error/typed');
+
+var BadPingReqPingStatusError = TypedError({
+    type: 'ringpop.ping-req.bad-ping-status',
+    message: 'Bad ping status from ping-req ping: {pingStatus}',
+    selected: null,
+    target: null,
+    pingStatus: null
+});
+
+var BadPingReqRespBodyError = TypedError({
+    type: 'ringpop.ping-req.bad-resp-body',
+    message: 'Bad response from ping-req: {body}',
+    selected: null,
+    target: null,
+    body: null
+});
+
+var NoMembersError = TypedError({
+    type: 'ringpop.ping-req.no-members',
+    message: 'No selectable ping-req members'
+});
+
+var PingReqInconclusiveError = TypedError({
+    type: 'ringpop.ping-req.inconclusive',
+    message: 'Ping-req is inconclusive'
+});
+
+var PingReqPingError = TypedError({
+    type: 'ringpop.ping-req.ping',
+    message: 'An error occurred on ping-req ping: {errMessage}',
+    errMessage: null
+});
+
+function body(sender) {
+    return JSON.stringify({
+        checksum: sender.ring.membership.checksum,
+        changes: sender.ring.issueMembershipChanges(),
+        source: sender.ring.whoami(),
+        target: sender.target.address
+    });
+}
+
+function sendOptions(sender)  {
+    return {
+        host: sender.member.address,
+        timeout: sender.ring.pingReqTimeout
+    };
+}
 
 function PingReqSender(ring, member, target, callback) {
     this.ring = ring;
     this.member = member;
     this.target = target;
     this.callback = callback;
-
-    var options = {
-        host: member.address,
-        timeout: this.ring.pingReqTimeout
-    };
-    var body = JSON.stringify({
-        checksum: this.ring.membership.checksum,
-        changes: this.ring.issueMembershipChanges(),
-        source: this.ring.whoami(),
-        target: target.address
-    });
-
-    var self = this;
-    this.ring.channel.send(options, '/protocol/ping-req', null, body, function(err, res1, res2) {
-        self.onPingReq(err, res1, res2);
-    });
 }
+
+PingReqSender.prototype.send = function send() {
+    var self = this;
+
+    this.ring.channel.send(sendOptions(this), '/protocol/ping-req', null, body(this), onSend);
+
+    function onSend(err, res1, res2) {
+        self.onPingReq(err, res1, res2);
+    }
+};
 
 PingReqSender.prototype.onPingReq = function (err, res1, res2) {
     if (err) {
         this.ring.logger.warn('bad response to ping-req from ' + this.member.address + ' err=' + err.message);
-        return this.callback(true);
+        this.callback(PingReqPingError({
+            errMessage: err.message
+        }));
+        return;
     }
 
-    var bodyObj = safeParse(res2.toString());
+    var res2Str = res2.toString();
+    var bodyObj = safeParse(res2Str);
     if (! bodyObj || !bodyObj.changes || bodyObj.pingStatus === 'undefined') {
         this.ring.logger.warn('bad response body in ping-req from ' + this.member.address);
-        return this.callback(true);
+        this.callback(BadPingReqRespBodyError({
+            selected: this.member.address,
+            target: this.target.address,
+            body: res2Str
+        }));
+        return;
     }
 
     this.ring.membership.update(bodyObj.changes);
     this.ring.debugLog('ping-req recv peer=' + this.member.address + ' target=' + this.target.address + ' isOk=' + bodyObj.pingStatus);
-    this.callback(!!!bodyObj.pingStatus); // I don't not totally understand this line
+
+    if (!bodyObj.pingStatus) {
+        this.callback(BadPingReqPingStatusError({
+            selected: this.member.address,
+            target: this.target.address,
+            pingStatus: bodyObj.pingStatus
+        }));
+        return;
+    }
+
+    this.callback();
 };
 
-module.exports = PingReqSender;
+module.exports = function sendPingReq(opts, callback) {
+    var ringpop = opts.ringpop;
+    var unreachableMember = opts.unreachableMember;
+    var pingReqSize = opts.pingReqSize;
+
+    ringpop.stat('increment', 'ping-req.send');
+
+    var pingReqMembers = randomMembers();
+    ringpop.stat('timing', 'ping-req.other-members', pingReqMembers.length);
+
+    if (pingReqMembers.length === 0) {
+        callback(NoMembersError());
+        return;
+    }
+
+    var addrs = pingReqAddrs(pingReqMembers);
+    var calledBack = false;
+    var errors = [];
+    var startTime = Date.now();
+    var unreachableMemberInfo = {
+        address: unreachableMember.address,
+        startingStatus: unreachableMember.status
+    };
+
+    for (var i = 0; i < pingReqMembers.length; i++) {
+        var pingReqMember = pingReqMembers[i];
+
+        // TODO Cleanup this log site
+        ringpop.debugLog('ping-req send peer=' + pingReqMember.address +
+            ' target=' + unreachableMember.address, 'p');
+
+        var sender = new PingReqSender(ringpop, pingReqMember, unreachableMember,
+            onPingReqHandler(pingReqMember, pingReqMember.status));
+        sender.send();
+    }
+
+    function onPingReqHandler(pingReqMember, startingStatus) {
+        return function onPingReq(err) {
+            if (calledBack) {
+                return;
+            }
+
+            var pingReqMemberInfo = {
+                address: pingReqMember.address,
+                startingStatus: startingStatus,
+                endingStatus: pingReqMember.status
+            };
+
+            // NOTE If the member is reachable, we don't explicitly
+            // mark the unreachable member alive here. It happens
+            // through implicit exchange of membership updates on
+            // ping-req requests and responses.
+            if (!err) {
+                ringpop.logger.info('ringpop ping-req determined member is reachable', {
+                    local: ringpop.whoami(),
+                    errors: errors,
+                    numErrors: errors.length,
+                    numPingReqMembers: pingReqMembers.length,
+                    pingReqAddrs: addrs,
+                    pingReqMemberInfo: pingReqMemberInfo,
+                    totalPingReqTime: Date.now() - startTime,
+                    unreachableMemberInfo: unreachableMemberInfo
+                });
+
+                calledBack = true;
+                callback(null, {
+                    pingReqAddrs: addrs,
+                    pingReqSuccess: pingReqMemberInfo
+                });
+                return;
+            }
+
+            errors.push(err);
+
+            if (errors.length < pingReqMembers.length) {
+                // Keep waiting for responses...
+                return;
+            }
+
+            // A ping-req request may result in many types of errors.
+            // The only ones that should count against the unreachable
+            // member are those that have a valid response from a
+            // chosen ping-req member that also could not reach that
+            // member. If all errors are of that type, then make the
+            // unreachable member a suspect.
+            var numPingReqStatusErrs = 0;
+
+            for (var i = 0; i < errors.length; i++) {
+                var error = errors[i];
+
+                if (error.type === 'ringpop.ping-req.bad-ping-status') {
+                    numPingReqStatusErrs++;
+                }
+            }
+
+            if (numPingReqStatusErrs > 0) {
+                ringpop.logger.warn('ringpop ping-req determined member is unreachable', {
+                    local: ringpop.whoami(),
+                    errors: errors,
+                    numErrors: errors.length,
+                    numPingReqMembers: pingReqMembers.length,
+                    numPingReqStatusErrs: numPingReqStatusErrs,
+                    pingReqAddrs: addrs,
+                    totalPingReqTime: Date.now() - startTime,
+                    unreachableMemberInfo: unreachableMemberInfo
+                });
+
+                ringpop.membership.makeSuspect(unreachableMember.address);
+
+                calledBack = true;
+                callback(null, {
+                    pingReqAddrs: addrs,
+                    pingReqErrs: errors
+                });
+            } else {
+                ringpop.logger.warn('ringpop ping-req inconclusive due to errors', {
+                    local: ringpop.whoami(),
+                    errors: errors,
+                    numErrors: errors.length,
+                    numPingReqMembers: pingReqMembers.length,
+                    numPingReqStatusErrs: numPingReqStatusErrs,
+                    pingReqAddrs: addrs,
+                    totalPingReqTime: Date.now() - startTime,
+                    unreachableMemberInfo: unreachableMemberInfo
+                });
+
+                calledBack = true;
+                callback(PingReqInconclusiveError());
+            }
+        };
+    }
+
+    function pingReqAddrs(pingReqMembers) {
+        return pingReqMembers.map(function mapMember(member) {
+            return member.address;
+        });
+    }
+
+    function randomMembers() {
+        return ringpop.membership.getRandomPingableMembers(
+            pingReqSize, [unreachableMember.address]);
+    }
+};

--- a/lib/tchannel.js
+++ b/lib/tchannel.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+var recvPingReq = require('./swim/ping-req-recvr.js');
 var safeParse = require('./util').safeParse;
 
 var commands = {
@@ -42,8 +43,8 @@ var commands = {
     '/proxy/req': 'proxyReq'
 };
 
-function RingPopTChannel(ringPop, tchannel) {
-    this.ringPop = ringPop;
+function RingPopTChannel(ringpop, tchannel) {
+    this.ringpop = ringpop;
     this.tchannel = tchannel;
 
     var self = this;
@@ -62,35 +63,35 @@ RingPopTChannel.prototype.health = function (arg1, arg2, hostInfo, cb) {
 };
 
 RingPopTChannel.prototype.adminStats = function (arg1, arg2, hostInfo, cb) {
-    cb(null, null, JSON.stringify(this.ringPop.getStats()));
+    cb(null, null, JSON.stringify(this.ringpop.getStats()));
 };
 
 RingPopTChannel.prototype.adminDebugSet = function (arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2.toString());
     if (body && body.debugFlag) {
-        this.ringPop.setDebugFlag(body.debugFlag);
+        this.ringpop.setDebugFlag(body.debugFlag);
     }
     cb(null, null, 'ok');
 };
 
 RingPopTChannel.prototype.adminDebugClear = function (arg1, arg2, hostInfo, cb) {
-    this.ringPop.clearDebugFlags();
+    this.ringpop.clearDebugFlags();
     cb(null, null, 'ok');
 };
 
 RingPopTChannel.prototype.adminGossip = function (arg1, arg2, hostInfo, cb) {
-    this.ringPop.gossip.start();
+    this.ringpop.gossip.start();
     cb(null, null, 'ok');
 };
 
 RingPopTChannel.prototype.adminLeave = function (arg1, arg2, hostInfo, cb) {
-    this.ringPop.adminLeave(cb);
+    this.ringpop.adminLeave(cb);
 };
 
 RingPopTChannel.prototype.adminJoin = function (arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2.toString()) || {};
     if (body) {
-        this.ringPop.adminJoin(function (err, candidateHosts) {
+        this.ringpop.adminJoin(function (err, candidateHosts) {
             if (err) {
                 return cb(err);
             }
@@ -106,14 +107,14 @@ RingPopTChannel.prototype.adminJoin = function (arg1, arg2, hostInfo, cb) {
 RingPopTChannel.prototype.adminReload = function (arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2.toString());
     if (body && body.file) {
-        this.ringPop.reload(body.file, function(err) {
+        this.ringpop.reload(body.file, function(err) {
             cb(err);
         });
     }
 };
 
 RingPopTChannel.prototype.adminTick = function (arg1, arg2, hostInfo, cb) {
-    this.ringPop.handleTick(function onTick(err, resp) {
+    this.ringpop.handleTick(function onTick(err, resp) {
         cb(err, null, JSON.stringify(resp));
     });
 };
@@ -131,7 +132,7 @@ RingPopTChannel.prototype.protocolJoin = function (arg1, arg2, hostInfo, cb) {
         return cb(new Error('need req body with app, source and incarnationNumber'));
     }
 
-    this.ringPop.protocolJoin({
+    this.ringpop.protocolJoin({
         app: app,
         source: source,
         incarnationNumber: incarnationNumber
@@ -148,14 +149,14 @@ RingPopTChannel.prototype.protocolLeave = function (arg1, arg2, hostInfo, cb) {
 
     var node = body.node;
 
-    this.ringPop.protocolLeave(node);
+    this.ringpop.protocolLeave(node);
 
     // In response send back `coordinator` which is node
     // that handled leave request, aka this node. This will
     // not be obvious to the requester as the leave could
     // happen through haproxy.
     cb(null, null, JSON.stringify({
-        coordinator: this.ringPop.whoami()
+        coordinator: this.ringpop.whoami()
     }));
 };
 
@@ -165,7 +166,7 @@ RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
         return cb(new Error('need req body with source, changes, and checksum'));
     }
 
-    this.ringPop.protocolPing({
+    this.ringpop.protocolPing({
         source: body.source,
         changes: body.changes,
         checksum: body.checksum
@@ -174,18 +175,19 @@ RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
     });
 };
 
-RingPopTChannel.prototype.protocolPingReq = function (arg1, arg2, hostInfo, cb) {
+RingPopTChannel.prototype.protocolPingReq = function protocolPingReq(arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2);
     if (body === null || !body.source || !body.target || !body.changes || !body.checksum) {
         return cb(new Error('need req body with source, target, changes, and checksum'));
     }
 
-    this.ringPop.protocolPingReq({
+    recvPingReq({
+        ringpop: this.ringpop,
         source: body.source,
         target: body.target,
         changes: body.changes,
         checksum: body.checksum
-    }, function(err, result) {
+    }, function onHandled(err, result) {
         cb(err, null, JSON.stringify(result));
     });
 };
@@ -196,11 +198,11 @@ RingPopTChannel.prototype.proxyReq = function (arg1, arg2, hostInfo, cb) {
         return cb(new Error('need header to exist'));
     }
 
-    this.ringPop.handleIncomingRequest(header, arg2, cb);
+    this.ringpop.handleIncomingRequest(header, arg2, cb);
 };
 
-function createRingPopTChannel(ringPop, tchannel) {
-    return new RingPopTChannel(ringPop, tchannel);
+function createRingPopTChannel(ringpop, tchannel) {
+    return new RingPopTChannel(ringpop, tchannel);
 }
 
 exports.createRingPopTChannel = createRingPopTChannel;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "add-licence": "uber-licence",
     "check-licence": "uber-licence --dry",
     "cover": "istanbul cover --print detail --report html test/index.js",
-    "jshint": "jshint --verbose *.js lib/*.js",
+    "jshint": "jshint --verbose *.js lib/**/*.js",
     "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
     "view-cover": "opn coverage/index.html"
   },

--- a/test/integration/join-test.js
+++ b/test/integration/join-test.js
@@ -40,6 +40,7 @@ testRingpopCluster({
     size: 1
 }, 'one node can join', function t(bootRes, cluster, assert) {
     assert.ifErr(bootRes[cluster[0].hostPort].err, 'no error occurred');
+    assert.end();
 });
 
 testRingpopCluster({
@@ -50,6 +51,8 @@ testRingpopCluster({
     cluster.forEach(function eachNode(node) {
         assert.ok(node.isReady, 'node is ready');
     });
+
+    assert.end();
 });
 
 testRingpopCluster('three nodes can join', function t(bootRes, cluster, assert) {
@@ -58,6 +61,8 @@ testRingpopCluster('three nodes can join', function t(bootRes, cluster, assert) 
     cluster.forEach(function eachNode(node) {
         assert.ok(node.isReady, 'node is ready');
     });
+
+    assert.end();
 });
 
 testRingpopCluster({
@@ -77,6 +82,8 @@ testRingpopCluster({
         assert.ok(nodesJoined.length >= 1, 'joined at least one other node');
         assert.ok(nodesJoined.indexOf(badNode) === -1, 'no one can join bad node');
     });
+
+    assert.end();
 });
 
 testRingpopCluster({
@@ -95,6 +102,8 @@ testRingpopCluster({
             'ringpop.join-duration-exceeded',
             'join duration exceeded error');
     });
+
+    assert.end();
 });
 
 testRingpopCluster({
@@ -105,6 +114,8 @@ testRingpopCluster({
     cluster.forEach(function eachNode(node) {
         assert.ok(node.isReady, 'node is bootstrapped');
     });
+
+    assert.end();
 });
 
 testRingpopCluster({
@@ -131,4 +142,5 @@ testRingpopCluster({
         'join aborted error');
 
     assert.ok(cluster[1].isReady, 'node two is ready');
+    assert.end();
 });

--- a/test/integration/swim-test.js
+++ b/test/integration/swim-test.js
@@ -1,0 +1,207 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var sendPingReq = require('../../lib/swim/ping-req-sender.js');
+var testRingpopCluster = require('../lib/test-ringpop-cluster.js');
+
+// Avoid depending upon mutation of member and find
+// member again and assert its status.
+function assertAlive(assert, ringpop, address) {
+    var member = ringpop.membership.findMemberByAddress(address);
+    assert.equals(member.status, 'alive', 'member is alive');
+}
+
+function assertSuspect(assert, ringpop, address) {
+    var member = ringpop.membership.findMemberByAddress(address);
+    assert.equals(member.status, 'suspect', 'member is suspect');
+}
+
+function assertNumBadStatuses(assert, res, num) {
+    var badStatuses = res.pingReqErrs.filter(function filterErr(err) {
+        return err.type === 'ringpop.ping-req.bad-ping-status';
+    });
+
+    assert.equals(badStatuses.length, num, 'correct number of bad statuses');
+}
+
+function mkNoGossip(cluster) {
+    var noop = function noop() {
+    };
+
+    cluster.forEach(function eachRingpop(ringpop) {
+        ringpop.gossip.start = noop;
+    });
+}
+
+function mkBadPingReqResponder(ringpop) {
+    ringpop.channel.register('/protocol/ping-req', function protocolPingReq(arg1, arg2, hostInfo, cb) {
+        cb(null, null, JSON.stringify('badbody'));
+    });
+}
+
+testRingpopCluster({
+    tap: function tap(cluster) {
+        mkNoGossip(cluster);
+    }
+}, 'ping-reqs 1 member', function t(bootRes, cluster, assert) {
+    var ringpop = cluster[0];
+    var unreachableMember = ringpop.membership.findMemberByAddress(cluster[1].hostPort);
+
+    sendPingReq({
+        ringpop: cluster[0],
+        unreachableMember: unreachableMember,
+        pingReqSize: 3
+    }, function onPingReq(err, res) {
+        assert.ifErr(err, 'no error occurred');
+        assert.equal(res.pingReqAddrs.length, 1,
+            'number of selected ping-req members is correct');
+        assert.ok(res.pingReqSuccess.address === cluster[2].hostPort,
+            'successful ping-req response from either member');
+        assert.end();
+    });
+});
+
+testRingpopCluster({
+    size: 5,
+    tap: function tap(cluster) {
+        mkNoGossip(cluster);
+    }
+}, 'ping-reqs pingReqSize members', function t(bootRes, cluster, assert) {
+    var ringpop = cluster[0];
+    var unreachableMember = ringpop.membership.
+        findMemberByAddress(cluster[1].hostPort);
+    var pingReqSize = 3;
+
+    sendPingReq({
+        ringpop: cluster[0],
+        unreachableMember: unreachableMember,
+        pingReqSize: pingReqSize
+    }, function onPingReq(err, res) {
+        assert.ifErr(err, 'no error occurred');
+        assert.equal(res.pingReqAddrs.length, pingReqSize,
+            'number of selected ping-req members is correct');
+        assertAlive(assert, ringpop, unreachableMember.address);
+        assert.end();
+    });
+});
+
+testRingpopCluster({
+    size: 5,
+    tap: function tap(cluster) {
+        mkNoGossip(cluster);
+    }
+}, 'ping-req target unreachable', function t(bootRes, cluster, assert) {
+    var badRingpop = cluster[4];
+    badRingpop.destroy();
+
+    var ringpop = cluster[0];
+    var unreachableMember = ringpop.membership.findMemberByAddress(badRingpop.hostPort);
+    var pingReqSize = 3;
+
+    sendPingReq({
+        ringpop: ringpop,
+        unreachableMember: unreachableMember,
+        pingReqSize: pingReqSize
+    }, function onPingReq(err, res) {
+        assert.ifErr(err, 'no error occurred');
+        assertNumBadStatuses(assert, res, pingReqSize);
+        assertSuspect(assert, ringpop, unreachableMember.address);
+        assert.end();
+    });
+});
+
+testRingpopCluster({
+    size: 2,
+    tap: function tap(cluster) {
+        mkNoGossip(cluster);
+    }
+}, 'no ping-req members', function t(bootRes, cluster, assert) {
+    var ringpop = cluster[0];
+    var ringpop2Addr = cluster[1].hostPort;
+
+    var unreachableMember = ringpop.membership.findMemberByAddress(ringpop2Addr);
+    var pingReqSize = 3;
+
+    sendPingReq({
+        ringpop: ringpop,
+        unreachableMember: unreachableMember,
+        pingReqSize: pingReqSize
+    }, function onPingReq(err, res) {
+        assert.ok(err, 'error occurred');
+        assert.equals(err.type, 'ringpop.ping-req.no-members', 'No members error');
+        assert.end();
+    });
+});
+
+testRingpopCluster({
+    size: 5,
+    tap: function tap(cluster) {
+        mkBadPingReqResponder(cluster[3]);
+        mkNoGossip(cluster);
+    }
+}, 'some bad ping-statuses', function t(bootRes, cluster, assert) {
+    var badRingpop = cluster[4];
+    badRingpop.destroy();
+
+    var ringpop = cluster[0];
+    var unreachableMember = ringpop.membership.findMemberByAddress(badRingpop.hostPort);
+    var pingReqSize = 3;
+
+    sendPingReq({
+        ringpop: ringpop,
+        unreachableMember: unreachableMember,
+        pingReqSize: pingReqSize
+    }, function onPingReq(err, res) {
+        assert.ifErr(err, 'no error occurred');
+        assertNumBadStatuses(assert, res, pingReqSize - 1);
+        assertSuspect(assert, ringpop, unreachableMember.address);
+        assert.end();
+    });
+});
+
+testRingpopCluster({
+    size: 5,
+    tap: function tap(cluster) {
+        mkNoGossip(cluster);
+    }
+}, 'ping-req inconclusive', function t(bootRes, cluster, assert) {
+    var ringpop = cluster[0];
+    var unreachableMember = ringpop.membership.findMemberByAddress(cluster[4].hostPort);
+    var pingReqSize = 3;
+
+    // Mutating all member addresses to make each of selected ping-req members
+    // unreachable and therefore, the results of ping-req inconclusive.
+    ringpop.membership.members.forEach(function eachMember(member) {
+        member.address += '001';
+    });
+
+    sendPingReq({
+        ringpop: ringpop,
+        unreachableMember: unreachableMember,
+        pingReqSize: pingReqSize
+    }, function onPingReq(err) {
+        assert.ok(err, 'an error occurred');
+        assert.equal(err.type, 'ringpop.ping-req.inconclusive',
+            'ping-req is inconclusive');
+        assertAlive(assert, ringpop, unreachableMember.address);
+        assert.end();
+    });
+});

--- a/test/lib/test-ringpop-cluster.js
+++ b/test/lib/test-ringpop-cluster.js
@@ -58,7 +58,9 @@ function bootstrapClusterOf(opts, onBootstrap) {
     for (var i = 0; i < cluster.length; i++) {
         var ringpop = cluster[i];
 
-        ringpop.bootstrap(bootstrapHosts, Array.isArray(onBootstrap) ?
+        ringpop.bootstrap({
+            bootstrapFile: bootstrapHosts
+        }, Array.isArray(onBootstrap) ?
             onBootstrap[i] : bootstrapHandler(ringpop.hostPort));
     }
 
@@ -118,10 +120,11 @@ function testRingpopCluster(opts, name, test) {
 
     tape(name, function onTest(assert) {
         var cluster = bootstrapClusterOf(opts, function onBootstrap(results) {
-            test(results, cluster, assert);
+            assert.on('end', function onEnd() {
+                destroyCluster(cluster);
+            });
 
-            assert.end();
-            destroyCluster(cluster);
+            test(results, cluster, assert);
         });
     });
 }


### PR DESCRIPTION
This work is precursor to flap damping. Ping-req's needed to work better.

When nodeA pings nodeB and ping fails, nodeA initiates ping-req to `pingReqSize` random other members: nodeC, nodeD, nodeE. It's each of their responsibilities to ping nodeB on nodeA's behalf. This is known as an indirect ping. When nodeA pings the selected ping-req members (let's say nodeC), one of two things can happen:

1) nodeA cannot reach ping-req member nodeC
2) nodeA reaches nodeC, nodeC cannot reach nodeB.

The first of these two should not count against nodeB. This comes into play in flap damping in the following way. Let's say, nodeB is the flappy one and nodeA damp score for nodeB is nearing the damping threshold. Pings and ping-reqs to nodeB are failing. Every once and a while nodeB responds. It's acting erratically. What makes nodeB not think that nodeA is the flappy one? Well, nodeB has to initiate ping-reqs when pings to nodeA fails. But when nodeB is acting erratically, it's likely that nodeB is at fault for nodeA "not responding". If any of the ping-req selected members are able to reach nodeA, then nodeB will never mark nodeA suspect nor will it ever start the suspect period and ultimately never mark the node faulty. Therefore, nodeA should not ever be flappy to nodeB.

@Raynos @mrhooray @mranney 
 