### PR TITLE
Fix bug in admin leave so that it does cause neverending membership upda...

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,33 +215,6 @@ RingPop.prototype.adminJoin = function adminJoin(callback) {
     }, callback);
 };
 
-RingPop.prototype.adminLeave = function adminLeave(callback) {
-    if (!this.membership.localMember) {
-        process.nextTick(function() {
-            callback(errors.InvalidLocalMemberError());
-        });
-        return;
-    }
-
-    if (this.membership.localMember.status === 'leave') {
-        process.nextTick(function() {
-            callback(errors.RedundantLeaveError());
-        });
-        return;
-    }
-
-    // TODO Explicitly infect other members (like admin join)?
-    this.membership.makeLeave(this.whoami(),
-        this.membership.localMember.incarnationNumber);
-
-    this.gossip.stop();
-    this.suspicion.stopAll();
-
-    process.nextTick(function() {
-        callback(null, null, 'ok');
-    });
-};
-
 RingPop.prototype.bootstrap = function bootstrap(opts, callback) {
     var bootstrapFile = opts.bootstrapFile || opts;
 

--- a/lib/admin-leave-recvr.js
+++ b/lib/admin-leave-recvr.js
@@ -17,38 +17,41 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 'use strict';
 
-function MembershipIterator(ring) {
-    this.ring = ring;
-    this.currentIndex = -1;
-    this.currentRound = 0;
-}
+var errors = require('./errors.js');
+var TypedError = require('error/typed');
 
-MembershipIterator.prototype.next = function next() {
-    var membersVisited = {};
-    var maxMembersToVisit = this.ring.membership.getMemberCount();
+var RedundantLeaveError = TypedError({
+    type: 'ringpop.invalid-leave.redundant',
+    message: 'A node cannot leave its cluster when it has already left.'
+});
 
-    while (Object.keys(membersVisited).length < maxMembersToVisit) {
-        this.currentIndex++;
+module.exports = function recvAdminLeave(opts, callback) {
+    var ringpop = opts.ringpop;
 
-        if (this.currentIndex >= this.ring.membership.getMemberCount()) {
-            this.currentIndex = 0;
-            this.currentRound++;
-            this.ring.membership.shuffle();
-        }
-
-        var member = this.ring.membership.getMemberAt(this.currentIndex);
-
-        membersVisited[member.address] = true;
-
-        if (this.ring.membership.isPingable(member)) {
-            return member;
-        }
+    if (!ringpop.membership.localMember) {
+        process.nextTick(function() {
+            callback(errors.InvalidLocalMemberError());
+        });
+        return;
     }
 
-    return null;
-};
+    if (ringpop.membership.localMember.status === 'leave') {
+        process.nextTick(function() {
+            callback(RedundantLeaveError());
+        });
+        return;
+    }
 
-module.exports = MembershipIterator;
+    // TODO Explicitly infect other members (like admin join)?
+    ringpop.membership.makeLeave(ringpop.whoami(),
+        ringpop.membership.localMember.incarnationNumber);
+
+    ringpop.gossip.stop();
+    ringpop.suspicion.stopAll();
+
+    process.nextTick(function() {
+        callback(null, null, 'ok');
+    });
+};

--- a/lib/dissemination.js
+++ b/lib/dissemination.js
@@ -20,8 +20,6 @@
 
 'use strict';
 
-var MembershipUpdateRules = require('./membership-update-rules.js');
-
 var LOG_10 = Math.log(10);
 
 function Dissemination(ringpop) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -99,9 +99,5 @@ module.exports = {
         type: 'ringpop.options.property-required',
         message: 'Expected `{property}` to be defined within options argument.',
         property: null
-    }),
-    RedundantLeaveError: TypedError({
-        type: 'ringpop.invalid-leave.redundant',
-        message: 'A node cannot leave its cluster when it has already left.'
     })
 };

--- a/lib/membership-update-rules.js
+++ b/lib/membership-update-rules.js
@@ -26,37 +26,37 @@ function isAliveOverride(member, change) {
     return change.status === 'alive' &&
         Member.Status[member.status] &&
         change.incarnationNumber > member.incarnationNumber;
-};
+}
 
 function isFaultyOverride(member, change) {
     return change.status === 'faulty' &&
         ((member.status === 'suspect' && change.incarnationNumber >= member.incarnationNumber) ||
         (member.status === 'faulty' && change.incarnationNumber > member.incarnationNumber) ||
         (member.status === 'alive' && change.incarnationNumber >= member.incarnationNumber));
-};
+}
 
 function isLeaveOverride(member, change) {
     return change.status === 'leave' &&
-        Member.Status[member.status] &&
+        member.status !== Member.Status.leave &&
         change.incarnationNumber >= member.incarnationNumber;
-};
+}
 
 function isLocalFaultyOverride(ringpop, member, change) {
     return ringpop.whoami() === member.address &&
         change.status === Member.Status.faulty;
-};
+}
 
 function isLocalSuspectOverride(ringpop, member, change) {
     return ringpop.whoami() === member.address &&
         change.status === Member.Status.suspect;
-};
+}
 
 function isSuspectOverride(member, change) {
     return change.status === 'suspect' &&
         ((member.status === 'suspect' && change.incarnationNumber > member.incarnationNumber) ||
         (member.status === 'faulty' && change.incarnationNumber > member.incarnationNumber) ||
         (member.status === 'alive' && change.incarnationNumber >= member.incarnationNumber));
-};
+}
 
 module.exports = {
     isAliveOverride: isAliveOverride,

--- a/lib/membership.js
+++ b/lib/membership.js
@@ -88,7 +88,7 @@ Membership.prototype.getLocalMemberAddress = function getLocalMemberAddress() {
     return this.localMember && this.localMember.address;
 };
 
-Membership.prototype.getJoinPosition = function getJoinPosition(ringpop) {
+Membership.prototype.getJoinPosition = function getJoinPosition() {
     return Math.floor(Math.random() * (this.members.length - 0)) + 0;
 };
 
@@ -125,8 +125,8 @@ Membership.prototype.hasMember = function hasMember(member) {
 };
 
 Membership.prototype.isPingable = function isPingable(member) {
-    return member.address !== this.ringpop.whoami()
-        && (member.status === 'alive' ||
+    return member.address !== this.ringpop.whoami() &&
+        (member.status === 'alive' ||
         member.status === 'suspect');
 };
 
@@ -261,7 +261,7 @@ Membership.prototype.update = function update(changes) {
 
         return member;
     }
-}
+};
 
 Membership.prototype.shuffle = function shuffle() {
     this.members = _.shuffle(this.members);

--- a/lib/tchannel.js
+++ b/lib/tchannel.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+var recvAdminLeave = require('./admin-leave-recvr.js');
 var recvPingReq = require('./swim/ping-req-recvr.js');
 var safeParse = require('./util').safeParse;
 
@@ -84,8 +85,10 @@ RingPopTChannel.prototype.adminGossip = function (arg1, arg2, hostInfo, cb) {
     cb(null, null, 'ok');
 };
 
-RingPopTChannel.prototype.adminLeave = function (arg1, arg2, hostInfo, cb) {
-    this.ringpop.adminLeave(cb);
+RingPopTChannel.prototype.adminLeave = function adminLeave(arg1, arg2, hostInfo, cb) {
+    recvAdminLeave({
+        ringpop: this.ringpop
+    }, cb);
 };
 
 RingPopTChannel.prototype.adminJoin = function (arg1, arg2, hostInfo, cb) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "add-licence": "uber-licence",
     "check-licence": "uber-licence --dry",
     "cover": "istanbul cover --print detail --report html test/index.js",
-    "jshint": "jshint --verbose *.js lib/**/*.js",
+    "jshint": "jshint --verbose *.js lib/*.js lib/request-proxy/*.js lib/swim/*.js",
     "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
     "view-cover": "opn coverage/index.html"
   },

--- a/test/membership-test.js
+++ b/test/membership-test.js
@@ -22,7 +22,6 @@
 
 // Test dependencies
 var Member = require('../lib/member.js');
-var MembershipUpdateRules = require('../lib/membership-update-rules.js');
 
 // Test helpers
 var testRingpop = require('./lib/test-ringpop.js');
@@ -62,7 +61,6 @@ testRingpop('checksum is changed when membership is updated', function t(deps, a
 
 testRingpop('change with higher incarnation number results in leave override', function t(deps, assert) {
     var ringpop = deps.ringpop;
-    var dissemination = deps.dissemination;
     var membership = deps.membership;
 
     var member = membership.findMemberByAddress(ringpop.whoami());
@@ -79,7 +77,6 @@ testRingpop('change with higher incarnation number results in leave override', f
 
 testRingpop('change with same incarnation number does not result in leave override', function t(deps, assert) {
     var ringpop = deps.ringpop;
-    var dissemination = deps.dissemination;
     var membership = deps.membership;
 
     var member = membership.findMemberByAddress(ringpop.whoami());
@@ -96,7 +93,6 @@ testRingpop('change with same incarnation number does not result in leave overri
 
 testRingpop('change with lower incarnation number does not result in leave override', function t(deps, assert) {
     var ringpop = deps.ringpop;
-    var dissemination = deps.dissemination;
     var membership = deps.membership;
 
     var member = membership.findMemberByAddress(ringpop.whoami());
@@ -112,8 +108,6 @@ testRingpop('change with lower incarnation number does not result in leave overr
 });
 
 testRingpop('member is able to go from alive to faulty without going through suspect', function t(deps, assert) {
-    var ringpop = deps.ringpop;
-    var dissemination = deps.dissemination;
     var membership = deps.membership;
 
     var newMemberAddr = '127.0.0.1:3001';
@@ -137,4 +131,20 @@ testRingpop('member is able to go from alive to faulty without going through sus
     }]);
 
     assert.equals(newMember.status, Member.Status.faulty, 'override with same inc no.');
+});
+
+testRingpop('leave does not cause neverending updates', function t(deps, assert) {
+    var membership = deps.membership;
+
+    var addr = '127.0.0.1:3001';
+    var incNo = Date.now();
+
+    var updates = membership.makeAlive(addr, incNo);
+    assert.equals(updates.length, 1, 'alive update applied');
+
+    updates = membership.makeLeave(addr, incNo);
+    assert.equals(updates.length, 1, 'leave update applied');
+
+    updates = membership.makeLeave(addr, incNo);
+    assert.equals(updates.length, 0, 'no leave update applied');
 });


### PR DESCRIPTION
...tes

At some point this bug was introduced causing 'admin-leave' to malfunction by causing never ending membership updates. While the cluster converged quickly and gracefully, the override rules should prevent a member in the 'leave' status from repeatedly processing the 'leave' update.

Also, bear with the slight refactorings as I continue to hack away at the public interface of Ringpop and trim it down as much as possible.

@Raynos 