### PR TITLE
Minor refactor to sending pings ahead of damping

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var hammock = require('uber-hammock');
 var metrics = require('metrics');
 
 var Gossip = require('./lib/swim/gossip');
-var PingSender = require('./lib/swim/ping-sender');
+var sendPing = require('./lib/swim/ping-sender.js');
 var sendPingReq = require('./lib/swim/ping-req-sender.js');
 var Suspicion = require('./lib/swim/suspicion');
 
@@ -569,7 +569,10 @@ RingPop.prototype.pingMemberNow = function pingMemberNow(callback) {
     var self = this;
     this.isPinging = true;
     var start = new Date();
-    this.sendPing(member, function(isOk, body) {
+    sendPing({
+        ringpop: self,
+        target: member
+    }, function(isOk, body) {
         self.stat('timing', 'ping', start);
         if (isOk) {
             self.isPinging = false;
@@ -643,11 +646,6 @@ RingPop.prototype.seedBootstrapHosts = function seedBootstrapHosts(file) {
             this.readHostsFile(this.bootstrapFile) ||
             this.readHostsFile('./hosts.json');
     }
-};
-
-RingPop.prototype.sendPing = function sendPing(member, callback) {
-    this.stat('increment', 'ping.send');
-    return new PingSender(this, member, callback);
 };
 
 RingPop.prototype.setDebugFlag = function setDebugFlag(flag) {

--- a/lib/swim/ping-req-recvr.js
+++ b/lib/swim/ping-req-recvr.js
@@ -19,6 +19,8 @@
 // THE SOFTWARE.
 'use strict';
 
+var sendPing = require('./ping-sender.js');
+
 module.exports = function recvPingReq(opts, callback) {
     var ringpop = opts.ringpop;
 
@@ -36,7 +38,10 @@ module.exports = function recvPingReq(opts, callback) {
     ringpop.debugLog('ping-req send ping source=' + source + ' target=' + target, 'p');
 
     var start = new Date();
-    ringpop.sendPing(target, function (isOk, body) {
+    sendPing({
+        ringpop: ringpop,
+        target: target
+    }, function (isOk, body) {
         ringpop.stat('timing', 'ping-req-ping', start);
         ringpop.debugLog('ping-req recv ping source=' + source + ' target=' + target + ' isOk=' + isOk, 'p');
 

--- a/lib/swim/ping-sender.js
+++ b/lib/swim/ping-sender.js
@@ -24,24 +24,6 @@ function PingSender(ring, member, callback) {
     this.ring = ring;
     this.address = member.address || member;
     this.callback = callback;
-
-    var options = {
-        host: this.address,
-        timeout: ring.pingTimeout
-    };
-    var changes = ring.dissemination.issueChanges();
-    var body = JSON.stringify({
-        checksum: ring.membership.checksum,
-        changes: changes,
-        source: ring.whoami()
-    });
-
-    this.ring.debugLog('ping send member=' + this.address + ' changes=' + JSON.stringify(changes), 'p');
-
-    var self = this;
-    this.ring.channel.send(options, '/protocol/ping', null, body, function(err, res1, res2) {
-        self.onPing(err, res1, res2);
-    });
 }
 
 PingSender.prototype.onPing = function onPing(err, res1, res2) {
@@ -71,4 +53,29 @@ PingSender.prototype.doCallback = function doCallback(isOk, bodyObj) {
     }
 };
 
-module.exports = PingSender;
+PingSender.prototype.send = function send() {
+    var options = {
+        host: this.address,
+        timeout: this.ring.pingTimeout
+    };
+    var changes = this.ring.dissemination.issueChanges();
+    var body = JSON.stringify({
+        checksum: this.ring.membership.checksum,
+        changes: changes,
+        source: this.ring.whoami()
+    });
+
+    this.ring.debugLog('ping send member=' + this.address + ' changes=' + JSON.stringify(changes), 'p');
+
+    var self = this;
+    this.ring.channel.send(options, '/protocol/ping', null, body, function(err, res1, res2) {
+        self.onPing(err, res1, res2);
+    });
+};
+
+module.exports = function sendPing(opts, callback) {
+    opts.ringpop.stat('increment', 'ping.send');
+
+    var sender = new PingSender(opts.ringpop, opts.target, callback);
+    sender.send();
+};


### PR DESCRIPTION
As the title states, a minor refactor to sending pings ahead of damping. This is just moving code around and making the send/recv pattern more uniform across gossiping.

@Raynos 