### PR TITLE
Remove dependency on local member

### DIFF
--- a/index.js
+++ b/index.js
@@ -436,7 +436,7 @@ RingPop.prototype.whoami = function whoami() {
 RingPop.prototype.onMemberAlive = function onMemberAlive(change) {
     this.stat('increment', 'membership-update.alive');
     this.logger.debug('member is alive', {
-        local: this.membership.localMember.address,
+        local: this.whoami(),
         alive: change.address
     });
 
@@ -448,7 +448,7 @@ RingPop.prototype.onMemberAlive = function onMemberAlive(change) {
 RingPop.prototype.onMemberFaulty = function onMemberFaulty(change) {
     this.stat('increment', 'membership-update.faulty');
     this.logger.debug('member is faulty', {
-        local: this.membership.localMember.address,
+        local: this.whoami(),
         faulty: change.address,
     });
 
@@ -460,7 +460,7 @@ RingPop.prototype.onMemberFaulty = function onMemberFaulty(change) {
 RingPop.prototype.onMemberLeave = function onMemberLeave(change) {
     this.stat('increment', 'membership-update.leave');
     this.logger.debug('member has left', {
-        local: this.membership.localMember.address,
+        local: this.whoami(),
         left: change.address
     });
 
@@ -472,7 +472,7 @@ RingPop.prototype.onMemberLeave = function onMemberLeave(change) {
 RingPop.prototype.onMemberSuspect = function onMemberSuspect(change) {
     this.stat('increment', 'membership-update.suspect');
     this.logger.debug('member is suspect', {
-        local: this.membership.localMember.address,
+        local: this.whoami(),
         suspect: change.address
     });
 

--- a/lib/membership.js
+++ b/lib/membership.js
@@ -84,10 +84,6 @@ Membership.prototype.generateChecksumString = function generateChecksumString() 
     return checksumStrings.sort().join(';');
 };
 
-Membership.prototype.getLocalMemberAddress = function getLocalMemberAddress() {
-    return this.localMember && this.localMember.address;
-};
-
 Membership.prototype.getJoinPosition = function getJoinPosition() {
     return Math.floor(Math.random() * (this.members.length - 0)) + 0;
 };

--- a/lib/swim/gossip.js
+++ b/lib/swim/gossip.js
@@ -68,7 +68,7 @@ Gossip.prototype.run = function run() {
 
             if (self.isStopped) {
                 self.ringpop.logger.debug('stopped recurring gossip loop', {
-                    local: self.ringpop.membership.getLocalMemberAddress()
+                    local: self.ringpop.whoami()
                 });
                 return;
             }
@@ -81,7 +81,7 @@ Gossip.prototype.run = function run() {
 Gossip.prototype.start = function start() {
     if (!this.isStopped) {
         this.ringpop.logger.debug('gossip has already started', {
-            local: this.ringpop.membership.getLocalMemberAddress()
+            local: this.ringpop.whoami()
         });
         return;
     }
@@ -92,7 +92,7 @@ Gossip.prototype.start = function start() {
     this.isStopped = false;
 
     this.ringpop.logger.debug('started gossip protocol', {
-        local: this.ringpop.membership.getLocalMemberAddress()
+        local: this.ringpop.whoami()
     });
 };
 
@@ -106,7 +106,7 @@ Gossip.prototype.startProtocolRateTimer = function startProtocolRateTimer() {
 Gossip.prototype.stop = function stop() {
     if (this.isStopped) {
         this.ringpop.logger.warn('gossip is already stopped', {
-            local: this.ringpop.membership.getLocalMemberAddress()
+            local: this.ringpop.whoami()
         });
         return;
     }
@@ -120,7 +120,7 @@ Gossip.prototype.stop = function stop() {
     this.isStopped = true;
 
     this.ringpop.logger.debug('stopped gossip protocol', {
-        local: this.ringpop.membership.getLocalMemberAddress()
+        local: this.ringpop.whoami()
     });
 };
 

--- a/lib/swim/join-sender.js
+++ b/lib/swim/join-sender.js
@@ -342,7 +342,7 @@ JoinCluster.prototype.joinNode = function joinNode(node, callback) {
     };
     var joinBody = JSON.stringify({
         app: this.ringpop.app,
-        source: this.ringpop.membership.localMember.address,
+        source: this.ringpop.whoami(),
         incarnationNumber: this.ringpop.membership.localMember.incarnationNumber
     });
 

--- a/lib/swim/suspicion.js
+++ b/lib/swim/suspicion.js
@@ -30,7 +30,7 @@ function Suspicion(options) {
 Suspicion.prototype.reenable = function reenable() {
     if (this.isStoppedAll !== true) {
         this.ringpop.logger.warn('cannot reenable suspicion protocol because it was never disabled', {
-            local: this.ringpop.membership.getLocalMemberAddress()
+            local: this.ringpop.whoami()
         });
         return;
     }
@@ -38,21 +38,21 @@ Suspicion.prototype.reenable = function reenable() {
     this.isStoppedAll = null;
 
     this.ringpop.logger.debug('reenabled suspicion protocol', {
-        local: this.ringpop.membership.getLocalMemberAddress()
+        local: this.ringpop.whoami()
     });
 };
 
 Suspicion.prototype.start = function start(member) {
     if (this.isStoppedAll === true) {
         this.ringpop.logger.debug('cannot start a suspect period because suspicion has not been reenabled', {
-            local: this.ringpop.membership.getLocalMemberAddress()
+            local: this.ringpop.whoami()
         });
         return;
     }
 
-    if (member.address === this.ringpop.membership.getLocalMemberAddress()) {
+    if (member.address === this.ringpop.whoami()) {
         this.ringpop.logger.debug('cannot start a suspect period for the local member', {
-            local: this.ringpop.membership.getLocalMemberAddress(),
+            local: this.ringpop.whoami(),
             suspect: member.address
         });
         return;
@@ -74,7 +74,7 @@ Suspicion.prototype.start = function start(member) {
     }, self.period);
 
     this.ringpop.logger.debug('started suspect period', {
-        local: this.ringpop.membership.getLocalMemberAddress(),
+        local: this.ringpop.whoami(),
         suspect: member.address
     });
 };
@@ -84,7 +84,7 @@ Suspicion.prototype.stop = function stop(member) {
     delete this.timers[member.address];
 
     this.ringpop.logger.debug('stopped members suspect timer', {
-        local: this.ringpop.membership.getLocalMemberAddress(),
+        local: this.ringpop.whoami(),
         suspect: member.address
     });
 };
@@ -96,7 +96,7 @@ Suspicion.prototype.stopAll = function stopAll() {
 
     if (timerKeys.length === 0) {
         this.ringpop.logger.debug('stopped no suspect timers', {
-            local: this.ringpop.membership.getLocalMemberAddress()
+            local: this.ringpop.whoami()
         });
         return;
     }
@@ -107,7 +107,7 @@ Suspicion.prototype.stopAll = function stopAll() {
     }, this);
 
     this.ringpop.logger.debug('stopped all suspect timers', {
-        local: this.ringpop.membership.getLocalMemberAddress(),
+        local: this.ringpop.whoami(),
         numTimers: timerKeys.length
     });
 };

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -39,10 +39,12 @@ function testRingpop(opts, name, test) {
 
         test({
             dissemination: ringpop.dissemination,
+            gossip: ringpop.gossip,
             iterator: ringpop.memberIterator,
             localMember: ringpop.membership.localMember,
             membership: ringpop.membership,
-            ringpop: ringpop
+            ringpop: ringpop,
+            suspicion: ringpop.suspicion
         }, assert);
 
         assert.end();

--- a/test/mock/membership.js
+++ b/test/mock/membership.js
@@ -33,7 +33,6 @@ module.exports = {
         address: '127.0.0.1:3002',
         incarnationNumber: 123456789
     },
-    getLocalMemberAddress: noop,
     makeFaulty: noop,
     shuffle: noop,
     update: noop


### PR DESCRIPTION
@Raynos This is the bug you ran into. We're trying to access localMember in places where it may not have been added yet (aka not bootstrapping). We can just as easily access ringpop's hostPort for the same value.

More validation needs to be added around what things should be possible if you've not yet bootstrapped ringpop, but i'll leave that for another PR.

I also rewrote most of the suspicion tests in this PR because they were originally poorly written.