### PR TITLE
Lookup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All other properties should be considered private. Any mutation of properties no
 **Events**
 * `ready` - ringpop has been bootstrapped
 * `changed` - ring or membership state is changed (DEPRECATED)
+* `lookup` - A key has been looked up. A single argument is provided to the listener which takes the shape: `{ timing: Number }`
 * `membershipChanged` - membership state has changed (status or incarnation number). A membership change may result in a ring change.
 * `requestProxy.checksumsDiffer` - a proxied request arrives at its destination and source/destination checksums differ
 * `requestProxy.requestProxied` - a request is sent over the proxy channel

--- a/index.js
+++ b/index.js
@@ -410,8 +410,13 @@ RingPop.prototype.protocolPing = function protocolPing(options, callback) {
 };
 
 RingPop.prototype.lookup = function lookup(key) {
-    this.stat('increment', 'lookup');
+    var startTime = Date.now();
+
     var dest = this.ring.lookup(key + '');
+
+    this.emit('lookup', {
+        timing: Date.now() - startTime
+    });
 
     if (!dest) {
         this.logger.debug('could not find destination for a key', {


### PR DESCRIPTION
@Raynos Allow ringpop clients to record lookup times. Moving away from the model where ringpop has statsd dependency.