### PR TITLE
WIP Gossip user data

### DIFF
--- a/index.js
+++ b/index.js
@@ -507,7 +507,7 @@ RingPop.prototype.pingMemberNow = function pingMemberNow(callback) {
         self.stat('timing', 'ping', start);
         if (isOk) {
             self.isPinging = false;
-            self.membership.update(body.changes);
+            self.dissemination.apply(body.piggyback);
             return callback();
         }
 

--- a/lib/admin-set-user-data-recvr.js
+++ b/lib/admin-set-user-data-recvr.js
@@ -19,20 +19,12 @@
 // THE SOFTWARE.
 'use strict';
 
-module.exports = function recvPing(opts, callback) {
-    var ringpop = opts.ringpop;
-    var source = opts.source;
-    var piggyback = opts.piggyback;
-    var checksum = opts.checksum;
+module.exports = function recvSetUserAdminData(opts, callback) {
+    var dissemination = opts.dissemination;
 
-    ringpop.stat('increment', 'ping.recv');
+    dissemination.recordUserData(opts.userData);
 
-    ringpop.serverRate.mark();
-    ringpop.totalRate.mark();
-
-    ringpop.dissemination.apply(piggyback);
-
-    callback(null, {
-        piggyback: ringpop.dissemination.issue(checksum, source)
+    process.nextTick(function onTick() {
+        callback(null, null, 'ok');
     });
 };

--- a/lib/disseminated-user-data.js
+++ b/lib/disseminated-user-data.js
@@ -19,20 +19,18 @@
 // THE SOFTWARE.
 'use strict';
 
-module.exports = function recvPing(opts, callback) {
-    var ringpop = opts.ringpop;
-    var source = opts.source;
-    var piggyback = opts.piggyback;
-    var checksum = opts.checksum;
+var _ = require('underscore');
 
-    ringpop.stat('increment', 'ping.recv');
+function UserData() {
+    this.store = {};
+}
 
-    ringpop.serverRate.mark();
-    ringpop.totalRate.mark();
+// TODO EventEmitter
 
-    ringpop.dissemination.apply(piggyback);
+UserData.prototype.add = function add(userData) {
+    _.extend(this.store, userData);
 
-    callback(null, {
-        piggyback: ringpop.dissemination.issue(checksum, source)
-    });
+    // TODO Expiration?
 };
+
+module.exports = UserData;

--- a/lib/dissemination.js
+++ b/lib/dissemination.js
@@ -17,18 +17,111 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 'use strict';
 
+var _ = require('underscore');
+var UserData = require('./disseminated-user-data.js');
+
 var LOG_10 = Math.log(10);
+
+function collectPiggybackData(collection, maxPiggybackCount) {
+    var piggybackData = [];
+
+    var keys = Object.keys(collection);
+
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+
+        var data = collection[key];
+
+        // NOTE We're bumping the piggyback count even though
+        // we don't know whether the change successfully made
+        // it over to the other side. This can result in undesired
+        // full-syncs.
+        if (typeof data.piggybackCount === 'undefined') {
+            data.piggybackCount = 0;
+        }
+
+        data.piggybackCount += 1;
+
+        if (data.piggybackCount > maxPiggybackCount) {
+            delete collection[key];
+            continue;
+        }
+
+        piggybackData.push(_.omit(data, 'piggybackCount'));
+    }
+
+    return piggybackData;
+}
+
+function issueChanges(dissemination, checksum, source) {
+    var ringpop = dissemination.ringpop;
+
+    var changesToDisseminate = collectPiggybackData(
+        dissemination.recordedChanges, dissemination.maxPiggybackCount);
+
+    ringpop.stat('gauge', 'changes.disseminate', changesToDisseminate.length);
+
+    if (changesToDisseminate.length) {
+        return changesToDisseminate;
+    } else if (checksum && ringpop.membership.checksum !== checksum) {
+        ringpop.stat('increment', 'full-sync');
+        ringpop.logger.info('full sync', {
+            localChecksum: ringpop.membership.checksum,
+            remoteChecksum: checksum,
+            remoteNode: source
+        });
+
+        // TODO Somehow send back indication of isFullSync
+        return dissemination.fullSync();
+    } else {
+        return [];
+    }
+}
+
+function issueUserData(dissemination) {
+    var piggybackData = [];
+
+    var recordedUserData = dissemination.recordedUserData;
+
+    for (var i = 0; i < recordedUserData.length; i++) {
+        var data = recordedUserData[i];
+
+        // NOTE We're bumping the piggyback count even though
+        // we don't know whether the change successfully made
+        // it over to the other side. This can result in undesired
+        // full-syncs.
+        if (typeof data.piggybackCount === 'undefined') {
+            data.piggybackCount = 0;
+        }
+
+        data.piggybackCount += 1;
+
+        if (data.piggybackCount > dissemination.maxPiggybackCount) {
+            // TODO track for splicing
+            continue;
+        }
+
+        piggybackData.push(_.omit(data, 'piggybackCount'));
+    }
+
+    // TODO Splice
+
+    return piggybackData;
+}
 
 function Dissemination(ringpop) {
     this.ringpop = ringpop;
     this.ringpop.on('changed', this.onRingChanged.bind(this));
 
-    this.changes = {};
+    this.recordedChanges = {};
+    this.recordedUserData = [];
+
     this.maxPiggybackCount = 1;
     this.piggybackFactor = 15; // A lower piggyback factor leads to more full-syncs
+
+    this.userDataStore = new UserData();
 }
 
 Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCount() {
@@ -45,6 +138,20 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
             piggybackFactor: this.piggybackFactor,
             serverCount: serverCount
         });
+    }
+};
+
+Dissemination.prototype.apply = function apply(piggyback) {
+    if (!piggyback) {
+        return;
+    }
+
+    if (piggyback.changes) {
+        this.ringpop.membership.update(piggyback.changes);
+    }
+
+    if (piggyback.userData) {
+        this.userDataStore.add(piggyback.userData);
     }
 };
 
@@ -65,57 +172,11 @@ Dissemination.prototype.fullSync = function fullSync() {
     return changes;
 };
 
-Dissemination.prototype.issueChanges = function issueChanges(checksum, source) {
-    var changesToDisseminate = [];
-
-    var changedNodes = Object.keys(this.changes);
-
-    for (var i = 0; i < changedNodes.length; i++) {
-        var address = changedNodes[i];
-        var change = this.changes[address];
-
-        // TODO We're bumping the piggyback count even though
-        // we don't know whether the change successfully made
-        // it over to the other side. This can result in undesired
-        // full-syncs.
-        if (typeof change.piggybackCount === 'undefined') {
-            change.piggybackCount = 0;
-        }
-
-        change.piggybackCount += 1;
-
-        if (change.piggybackCount > this.maxPiggybackCount) {
-            delete this.changes[address];
-            continue;
-        }
-
-        // TODO Compute change ID
-        // TODO Include change timestamp
-        changesToDisseminate.push({
-            source: change.source,
-            address: change.address,
-            status: change.status,
-            incarnationNumber: change.incarnationNumber
-        });
-    }
-
-    this.ringpop.stat('gauge', 'changes.disseminate', changesToDisseminate.length);
-
-    if (changesToDisseminate.length) {
-        return changesToDisseminate;
-    } else if (checksum && this.ringpop.membership.checksum !== checksum) {
-        this.ringpop.stat('increment', 'full-sync');
-        this.ringpop.logger.info('full sync', {
-            localChecksum: this.ringpop.membership.checksum,
-            remoteChecksum: checksum,
-            remoteNode: source
-        });
-
-        // TODO Somehow send back indication of isFullSync
-        return this.fullSync();
-    } else {
-        return [];
-    }
+Dissemination.prototype.issue = function issue(checksum, source) {
+    return {
+        changes: issueChanges(this, checksum, source),
+        userData: issueUserData(this)
+    };
 };
 
 Dissemination.prototype.onRingChanged = function onRingChanged() {
@@ -123,7 +184,11 @@ Dissemination.prototype.onRingChanged = function onRingChanged() {
 };
 
 Dissemination.prototype.recordChange = function recordChange(change) {
-    this.changes[change.address] = change;
+    this.recordedChanges[change.address] = change;
+};
+
+Dissemination.prototype.recordUserData = function recordUserData(userData) {
+    this.recordedUserData.push(userData);
 };
 
 module.exports = Dissemination;

--- a/lib/swim/join-sender.js
+++ b/lib/swim/join-sender.js
@@ -350,7 +350,7 @@ JoinCluster.prototype.joinNode = function joinNode(node, callback) {
         var bodyObj = safeParse(body.toString());
 
         if (bodyObj) {
-            self.ringpop.membership.update(bodyObj.membership);
+            self.ringpop.dissemination.apply(bodyObj.piggyback);
         }
 
         callback(null, node);

--- a/lib/swim/ping-req-recvr.js
+++ b/lib/swim/ping-req-recvr.js
@@ -28,12 +28,12 @@ module.exports = function recvPingReq(opts, callback) {
 
     var source = opts.source;
     var target = opts.target;
-    var changes = opts.changes;
+    var piggyback = opts.piggyback;
     var checksum = opts.checksum;
 
     ringpop.serverRate.mark();
     ringpop.totalRate.mark();
-    ringpop.membership.update(changes);
+    ringpop.dissemination.apply(piggyback);
 
     ringpop.debugLog('ping-req send ping source=' + source + ' target=' + target, 'p');
 
@@ -46,11 +46,11 @@ module.exports = function recvPingReq(opts, callback) {
         ringpop.debugLog('ping-req recv ping source=' + source + ' target=' + target + ' isOk=' + isOk, 'p');
 
         if (isOk) {
-            ringpop.membership.update(body.changes);
+            ringpop.dissemination.apply(body);
         }
 
         callback(null, {
-            changes: ringpop.dissemination.issueChanges(checksum, source),
+            piggyback: ringpop.dissemination.issue(checksum, source),
             pingStatus: isOk,
             target: target
         });

--- a/lib/swim/ping-req-sender.js
+++ b/lib/swim/ping-req-sender.js
@@ -56,7 +56,7 @@ var PingReqPingError = TypedError({
 function body(sender) {
     return JSON.stringify({
         checksum: sender.ring.membership.checksum,
-        changes: sender.ring.dissemination.issueChanges(),
+        piggyback: sender.ring.dissemination.issue(),
         source: sender.ring.whoami(),
         target: sender.target.address
     });
@@ -97,7 +97,7 @@ PingReqSender.prototype.onPingReq = function (err, res1, res2) {
 
     var res2Str = res2.toString();
     var bodyObj = safeParse(res2Str);
-    if (! bodyObj || !bodyObj.changes || bodyObj.pingStatus === 'undefined') {
+    if (! bodyObj || !bodyObj.piggyback || bodyObj.pingStatus === 'undefined') {
         this.ring.logger.warn('bad response body in ping-req from ' + this.member.address);
         this.callback(BadPingReqRespBodyError({
             selected: this.member.address,
@@ -107,7 +107,7 @@ PingReqSender.prototype.onPingReq = function (err, res1, res2) {
         return;
     }
 
-    this.ring.membership.update(bodyObj.changes);
+    this.ring.dissemination.apply(bodyObj.piggyback);
     this.ring.debugLog('ping-req recv peer=' + this.member.address + ' target=' + this.target.address + ' isOk=' + bodyObj.pingStatus);
 
     if (!bodyObj.pingStatus) {

--- a/lib/swim/ping-sender.js
+++ b/lib/swim/ping-sender.js
@@ -33,8 +33,8 @@ PingSender.prototype.onPing = function onPing(err, res1, res2) {
     }
 
     var bodyObj = safeParse(res2.toString());
-    if (bodyObj && bodyObj.changes) {
-        this.ring.membership.update(bodyObj.changes);
+    if (bodyObj) {
+        this.ring.dissemination.apply(bodyObj.piggyback);
         return this.doCallback(true, bodyObj);
     }
     this.ring.logger.warn('ping failed member=' + this.address + ' bad response body=' + res2.toString());
@@ -45,7 +45,7 @@ PingSender.prototype.onPing = function onPing(err, res1, res2) {
 PingSender.prototype.doCallback = function doCallback(isOk, bodyObj) {
     bodyObj = bodyObj || {};
 
-    this.ring.debugLog('ping response member=' + this.address + ' isOk=' + isOk + ' changes=' + JSON.stringify(bodyObj.changes), 'p');
+    this.ring.debugLog('ping response member=' + this.address + ' isOk=' + isOk + ' piggyback=' + JSON.stringify(bodyObj.piggyback), 'p');
 
     if (this.callback) {
         this.callback(isOk, bodyObj);
@@ -58,14 +58,14 @@ PingSender.prototype.send = function send() {
         host: this.address,
         timeout: this.ring.pingTimeout
     };
-    var changes = this.ring.dissemination.issueChanges();
+    var piggyback = this.ring.dissemination.issue();
     var body = JSON.stringify({
         checksum: this.ring.membership.checksum,
-        changes: changes,
+        piggyback: piggyback,
         source: this.ring.whoami()
     });
 
-    this.ring.debugLog('ping send member=' + this.address + ' changes=' + JSON.stringify(changes), 'p');
+    this.ring.debugLog('ping send member=' + this.address + ' changes=' + JSON.stringify(piggyback), 'p');
 
     var self = this;
     this.ring.channel.send(options, '/protocol/ping', null, body, function(err, res1, res2) {

--- a/lib/tchannel.js
+++ b/lib/tchannel.js
@@ -22,6 +22,7 @@
 
 var recvAdminJoin = require('./admin-join-recvr.js');
 var recvAdminLeave = require('./admin-leave-recvr.js');
+var recvAdminSetUserData = require('./admin-set-user-data-recvr.js');
 var recvJoin = require('./swim/join-recvr.js');
 var recvPing = require('./swim/ping-recvr.js');
 var recvPingReq = require('./swim/ping-req-recvr.js');
@@ -39,6 +40,7 @@ var commands = {
     '/admin/join': 'adminJoin',
     '/admin/reload': 'adminReload',
     '/admin/tick': 'adminTick',
+    '/admin/userData/set': 'adminSetUserData',
 
     '/protocol/join': 'protocolJoin',
     '/protocol/ping': 'protocolPing',
@@ -129,6 +131,20 @@ RingPopTChannel.prototype.adminTick = function (arg1, arg2, hostInfo, cb) {
     });
 };
 
+RingPopTChannel.prototype.adminSetUserData = function adminSetUserData(arg1, arg2, hostInfo, callback) {
+    var body = safeParse(arg2.toString());
+
+    if (!body) {
+        callback(new Error('User data is required'));
+        return;
+    }
+
+    recvAdminSetUserData({
+        dissemination: this.ringpop.dissemination,
+        userData: body
+    }, callback);
+};
+
 RingPopTChannel.prototype.protocolJoin = function (arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2.toString());
     if (body === null) {
@@ -154,15 +170,15 @@ RingPopTChannel.prototype.protocolJoin = function (arg1, arg2, hostInfo, cb) {
 
 RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2);
-    if (body === null || !body.source || !body.changes || !body.checksum) {
-        return cb(new Error('need req body with source, changes, and checksum'));
+    if (body === null || !body.source || !body.piggyback|| !body.checksum) {
+        return cb(new Error('need req body with source, piggyback, and checksum'));
     }
 
     recvPing({
         ringpop: this.ringpop,
         source: body.source,
-        changes: body.changes,
-        checksum: body.checksum
+        checksum: body.checksum,
+        piggyback: body.piggyback
     }, function(err, res) {
         cb(err, null, JSON.stringify(res));
     });
@@ -170,15 +186,15 @@ RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
 
 RingPopTChannel.prototype.protocolPingReq = function protocolPingReq(arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2);
-    if (body === null || !body.source || !body.target || !body.changes || !body.checksum) {
-        return cb(new Error('need req body with source, target, changes, and checksum'));
+    if (body === null || !body.source || !body.target || !body.piggyback || !body.checksum) {
+        return cb(new Error('need req body with source, target, piggyback, and checksum'));
     }
 
     recvPingReq({
         ringpop: this.ringpop,
         source: body.source,
         target: body.target,
-        changes: body.changes,
+        piggyback: body.piggyback,
         checksum: body.checksum
     }, function onHandled(err, result) {
         cb(err, null, JSON.stringify(result));


### PR DESCRIPTION
This is just a quick hack to get gossiping user data working, but this is the general scope of the work that needs to be done. Relatively close to completion (implementation-wise), but not quite there for a full-blown review. This PR is more for sharing purposes right now.

The technique applied for gossiping user data is the same used for gossiping membership changes. Much like the changes, user data is 'recorded' in the dissemination component. Upon the next protocol period, the recorded user data will be piggybacked with the ping request. The user data disseminated decays over time; probabilistically user data will make its way to every node. There's no state-checking/checksumming/anti-entropy of user data at this point. 

@kriskowal @Raynos @jcorbin 