### PR TITLE
swim/join: Abort the join process if attempts exceeded

### DIFF
--- a/lib/swim/join-sender.js
+++ b/lib/swim/join-sender.js
@@ -39,6 +39,14 @@ var JoinDurationExceededError = TypedError({
     max: null
 });
 
+var JoinAttemptsExceededError = TypedError({
+    type: 'ringpop.join-attempts-exceeded',
+    message: 'Join attempts of `{joinAttempts}` ' +
+        'exceeded max `{maxJoinAttempts}`.\n',
+    joinAttempts: null,
+    maxJoinAttempts: null
+});
+
 var JOIN_RETRY_DELAY = 100;
 var JOIN_SIZE = 3;
 var JOIN_TIMEOUT = 1000;
@@ -54,6 +62,7 @@ var JOIN_TIMEOUT = 1000;
 //   provisioned cluster
 //   - Trying forever is futile
 var MAX_JOIN_DURATION = 120000;
+var MAX_JOIN_ATTEMPTS = 50;
 var PARALLELISM_FACTOR = 2;
 
 function isSingleNodeCluster(ringpop) {
@@ -102,6 +111,11 @@ function JoinCluster(opts) {
     // to a certain time limit.
     this.maxJoinDuration = numOrDefault(opts.maxJoinDuration,
         MAX_JOIN_DURATION);
+
+    // We want to abort the joining process if we have failed
+    // a certain number of times.
+    this.maxJoinAttempts = numOrDefault(opts.maxJoinAttempts,
+        MAX_JOIN_ATTEMPTS);
 
     // We do not want to retry joining as hard as we can. We 
     // want to have some fixed backoff applied before we try
@@ -245,6 +259,22 @@ JoinCluster.prototype.join = function join(callback) {
 
             calledBack = true;
             callback(null, nodesJoined);
+        } else if (numFailed >= self.maxJoinAttempts) {
+            self.ringpop.logger.warn('ringpop max join attempts exceeded', {
+                local: self.ringpop.whoami(),
+                joinAttempts: numFailed,
+                maxJoinAttempts: self.maxJoinAttempts,
+                numJoined: numJoined,
+                numFailed: numFailed,
+                startTime: startTime
+            });
+
+            calledBack = true;
+            callback(JoinAttemptsExceededError({
+                joinAttempts: numFailed,
+                maxJoinAttempts: self.maxJoinAttempts
+            }));
+            return;
         } else {
             var joinDuration = Date.now() - startTime;
             if (joinDuration > self.maxJoinDuration) {

--- a/lib/swim/join-sender.js
+++ b/lib/swim/join-sender.js
@@ -39,6 +39,7 @@ var JoinDurationExceededError = TypedError({
     max: null
 });
 
+var JOIN_RETRY_DELAY = 100;
 var JOIN_SIZE = 3;
 var JOIN_TIMEOUT = 1000;
 // If a node cannot complete a join within MAX_JOIN_DURATION
@@ -101,6 +102,12 @@ function JoinCluster(opts) {
     // to a certain time limit.
     this.maxJoinDuration = numOrDefault(opts.maxJoinDuration,
         MAX_JOIN_DURATION);
+
+    // We do not want to retry joining as hard as we can. We 
+    // want to have some fixed backoff applied before we try
+    // to join again
+    this.joinRetryDelay = numOrDefault(opts.joinRetryDelay,
+        JOIN_RETRY_DELAY);
 
     // Potential nodes are nodes in the ringpop bootstrap
     // list that can be joined. Upon instantiation, this step
@@ -266,6 +273,10 @@ JoinCluster.prototype.join = function join(callback) {
                 numNodesLeft: self.joinSize - numJoined
             });
 
+            setTimeout(reJoin, self.joinRetryDelay);
+        }
+
+        function reJoin() {
             self.joinGroup(nodesJoined, onJoin);
         }
     }


### PR DESCRIPTION
We currently retry joining as hard as we can; in certain
edge cases I've seen it join 600 times in a row.

We should have a cap on it.

I've also added a fixed backoff of 100ms on every join
attempt to give the network some space to breath.

r: @jwolski @kriskowal