### PR TITLE
Dedupe multiple destinations on key lookups after failed proxy

### DIFF
--- a/lib/request-proxy/send.js
+++ b/lib/request-proxy/send.js
@@ -162,13 +162,13 @@ RequestProxySend.prototype.handleSuccess = function handleSuccess(res1, res2, ca
 };
 
 RequestProxySend.prototype.lookupKeys = function lookupKeys(keys) {
-    var dests = [];
+    var dests = {};
 
     for (var i = 0; i < keys.length; i++) {
-        dests.push(this.ringpop.lookup(keys[i]));
+        dests[this.ringpop.lookup(keys[i])] = true;
     }
 
-    return dests;
+    return Object.keys(dests);
 };
 
 RequestProxySend.prototype.rerouteRetry = function rerouteRetry(newDest, callback) {


### PR DESCRIPTION
Destinations were not deduped properly after a proxied request failed and thus would not be retried even if the lookup resulted in a single destination (w/ the same value)

@markyen @Raynos 