### PR TITLE
Prevent zalgo bomb on bad socket while forwarding request

### DIFF
--- a/lib/request-proxy/send.js
+++ b/lib/request-proxy/send.js
@@ -25,6 +25,11 @@ var rawHead = require('./util.js').rawHead;
 var strHead = require('./util.js').strHead;
 var TypedError = require('error/typed');
 
+var ChannelDestroyedError = TypedError({
+    type: 'ringpop.request-proxy.channel-destroyed',
+    message: 'Channel was destroyed before forwarding attempt'
+});
+
 var MaxRetriesExceeded = TypedError({
     type: 'ringpop.request-proxy.max-retries-exceeded',
     message: 'Max number of retries exceeded. {maxRetries} were attempted',
@@ -223,12 +228,19 @@ RequestProxySend.prototype.scheduleRetry = function scheduleRetry(callback) {
 RequestProxySend.prototype.send = function send(channelOpts, callback) {
     var self = this;
 
+    if (this.ringpop.channel.destroyed) {
+        process.nextTick(function onTick() {
+            callback(ChannelDestroyedError());
+        });
+        return;
+    }
+
     this.ringpop.channel.send(
         channelOpts,
         channelOpts.endpoint,
         this.getStrHead(),
         this.request.body,
-        this.maxRetries === 0 ? callback : onSend
+        this.maxRetries === 0 ? onSendNoRetries : onSend
     );
 
     this.ringpop.emit('requestProxy.requestProxied');
@@ -247,6 +259,12 @@ RequestProxySend.prototype.send = function send(channelOpts, callback) {
         }
 
         self.scheduleRetry(callback);
+    }
+
+    function onSendNoRetries(err, res1, res2) {
+        process.nextTick(function onTick() {
+            callback(err, res1, res2);
+        });
     }
 };
 


### PR DESCRIPTION
Lei found a problem while load testing. If no retries are specified, there's a chance that we can run into an error of this kind: `TypeError: Cannot call method 'destroy' of undefined` if the socket errors out in the context of writing to the socket for a forwarded request.

@Raynos @leizha 