### PR TITLE
Avoid disseminating redundant changes by filtering out change that or…

### DIFF
--- a/lib/dissemination.js
+++ b/lib/dissemination.js
@@ -54,6 +54,10 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
     }
 };
 
+Dissemination.prototype.clearChanges = function clearChanges() {
+    this.changes = [];
+};
+
 Dissemination.prototype.fullSync = function fullSync() {
     var changes = [];
 
@@ -71,56 +75,46 @@ Dissemination.prototype.fullSync = function fullSync() {
     return changes;
 };
 
-Dissemination.prototype.issueChanges = function issueChanges(checksum, source) {
-    var changesToDisseminate = [];
+Dissemination.prototype.issueAsSender = function issueAsSender() {
+    return issueAs(this, null, mapChanges);
 
-    var changedNodes = Object.keys(this.changes);
+    function mapChanges(changes) {
+        return changes;
+    }
+};
 
-    for (var i = 0; i < changedNodes.length; i++) {
-        var address = changedNodes[i];
-        var change = this.changes[address];
+Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, senderIncarnationNumber, senderChecksum) {
+    var self = this;
 
-        // TODO We're bumping the piggyback count even though
-        // we don't know whether the change successfully made
-        // it over to the other side. This can result in undesired
-        // full-syncs.
-        if (typeof change.piggybackCount === 'undefined') {
-            change.piggybackCount = 0;
-        }
+    return issueAs(this, filterChange, mapChanges);
 
-        change.piggybackCount += 1;
-
-        if (change.piggybackCount > this.maxPiggybackCount) {
-            delete this.changes[address];
-            continue;
-        }
-
-        // TODO Compute change ID
-        // TODO Include change timestamp
-        changesToDisseminate.push({
-            source: change.source,
-            address: change.address,
-            status: change.status,
-            incarnationNumber: change.incarnationNumber
-        });
+    function filterChange(change) {
+        return !!(senderAddr &&
+            senderIncarnationNumber &&
+            change.source &&
+            change.sourceIncarnationNumber &&
+            senderAddr === change.source &&
+            senderIncarnationNumber === change.sourceIncarnationNumber);
     }
 
-    this.ringpop.stat('gauge', 'changes.disseminate', changesToDisseminate.length);
+    function mapChanges(changes) {
+        // If no changes left to disseminate and checksums do not match, perform a full-sync.
+        if (changes.length > 0) {
+            return changes;
+        } else if (self.ringpop.membership.checksum !== senderChecksum) {
+            self.ringpop.stat('increment', 'full-sync');
+            self.ringpop.logger.info('full sync', {
+                local: self.ringpop.whoami(),
+                localChecksum: self.ringpop.membership.checksum,
+                dest: senderAddr,
+                destChecksum: senderChecksum
+            });
 
-    if (changesToDisseminate.length) {
-        return changesToDisseminate;
-    } else if (checksum && this.ringpop.membership.checksum !== checksum) {
-        this.ringpop.stat('increment', 'full-sync');
-        this.ringpop.logger.info('full sync', {
-            localChecksum: this.ringpop.membership.checksum,
-            remoteChecksum: checksum,
-            remoteNode: source
-        });
-
-        // TODO Somehow send back indication of isFullSync
-        return this.fullSync();
-    } else {
-        return [];
+            // TODO Somehow send back indication of isFullSync
+            return self.fullSync();
+        } else {
+            return [];
+        }
     }
 };
 
@@ -140,5 +134,50 @@ Dissemination.Defaults = {
     maxPiggybackCount: 1,
     piggybackFactor: 15 // A lower piggyback factor leads to more full-syncs
 };
+
+function issueAs(dissemination, filterChange, mapChanges) {
+    var changesToDisseminate = [];
+
+    var changedNodes = Object.keys(dissemination.changes);
+
+    for (var i = 0; i < changedNodes.length; i++) {
+        var address = changedNodes[i];
+        var change = dissemination.changes[address];
+
+        // TODO We're bumping the piggyback count even though
+        // we don't know whether the change successfully made
+        // it over to the other side. This can result in undesired
+        // full-syncs.
+        if (typeof change.piggybackCount === 'undefined') {
+            change.piggybackCount = 0;
+        }
+
+        if (typeof filterChange === 'function' && filterChange(change)) {
+            dissemination.ringpop.stat('increment', 'filtered-change');
+            continue;
+        }
+
+        change.piggybackCount += 1;
+
+        if (change.piggybackCount > dissemination.maxPiggybackCount) {
+            delete dissemination.changes[address];
+            continue;
+        }
+
+        // TODO Compute change ID
+        // TODO Include change timestamp
+        changesToDisseminate.push({
+            source: change.source,
+            sourceIncarnationNumber: change.sourceIncarnationNumber,
+            address: change.address,
+            status: change.status,
+            incarnationNumber: change.incarnationNumber
+        });
+    }
+
+    dissemination.ringpop.stat('gauge', 'changes.disseminate', changesToDisseminate.length);
+
+    return mapChanges(changesToDisseminate);
+}
 
 module.exports = Dissemination;

--- a/lib/membership-update-rollup.js
+++ b/lib/membership-update-rollup.js
@@ -72,7 +72,7 @@ MembershipUpdateRollup.prototype.flushBuffer = function flushBuffer() {
     var now = Date.now();
 
     var numUpdates = this.getNumUpdates();
-    this.ringpop.logger.info('ringpop flushed membership update buffer', {
+    this.ringpop.logger.debug('ringpop flushed membership update buffer', {
         local: this.ringpop.whoami(),
         checksum: this.ringpop.membership.checksum,
         sinceFirstUpdate: this.lastUpdateTime && (this.lastUpdateTime - this.firstUpdateTime),

--- a/lib/membership.js
+++ b/lib/membership.js
@@ -75,6 +75,10 @@ Membership.prototype.generateChecksumString = function generateChecksumString() 
     return checksumStrings.sort().join(';');
 };
 
+Membership.prototype.getIncarnationNumber = function getIncarnationNumber() {
+    return this.localMember && this.localMember.incarnationNumber;
+};
+
 Membership.prototype.getJoinPosition = function getJoinPosition() {
     return Math.floor(Math.random() * (this.members.length - 0)) + 0;
 };
@@ -117,9 +121,12 @@ Membership.prototype.isPingable = function isPingable(member) {
         member.status === 'suspect');
 };
 
-Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber, source) {
+Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
+    var localMember = this.localMember || {};
+
     return this.update({
-        source: source || this.ringpop.whoami(),
+        source: localMember.address,
+        sourceIncarnationNumber: localMember.incarnationNumber,
         address: address,
         status: Member.Status.alive,
         incarnationNumber: incarnationNumber,
@@ -127,9 +134,12 @@ Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber, 
     });
 };
 
-Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber, source) {
+Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
+    var localMember = this.localMember || {};
+
     return this.update({
-        source: source || this.ringpop.whoami(),
+        source: localMember.address,
+        sourceIncarnationNumber: localMember.incarnationNumber,
         address: address,
         status: Member.Status.faulty,
         incarnationNumber: incarnationNumber,
@@ -137,9 +147,12 @@ Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber
     });
 };
 
-Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber, source) {
+Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
+    var localMember = this.localMember || {};
+
     return this.update({
-        source: source || this.ringpop.whoami(),
+        source: localMember.address,
+        sourceIncarnationNumber: localMember.incarnationNumber,
         address: address,
         status: Member.Status.leave,
         incarnationNumber: incarnationNumber,
@@ -147,9 +160,12 @@ Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber, 
     });
 };
 
-Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber, source) {
+Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {
+    var localMember = this.localMember || {};
+
     return this.update({
-        source: source || this.ringpop.whoami(),
+        source: localMember.address,
+        sourceIncarnationNumber: localMember.incarnationNumber,
         address: address,
         status: Member.Status.suspect,
         incarnationNumber: incarnationNumber,

--- a/lib/swim/ping-recvr.js
+++ b/lib/swim/ping-recvr.js
@@ -22,6 +22,7 @@
 module.exports = function recvPing(opts, callback) {
     var ringpop = opts.ringpop;
     var source = opts.source;
+    var sourceIncarnationNumber = opts.sourceIncarnationNumber;
     var changes = opts.changes;
     var checksum = opts.checksum;
 
@@ -33,6 +34,7 @@ module.exports = function recvPing(opts, callback) {
     ringpop.membership.update(changes);
 
     callback(null, {
-        changes: ringpop.dissemination.issueChanges(checksum, source)
+        changes: ringpop.dissemination.issueAsReceiver(source,
+            sourceIncarnationNumber, checksum),
     });
 };

--- a/lib/swim/ping-req-recvr.js
+++ b/lib/swim/ping-req-recvr.js
@@ -27,6 +27,7 @@ module.exports = function recvPingReq(opts, callback) {
     ringpop.stat('increment', 'ping-req.recv');
 
     var source = opts.source;
+    var sourceIncarnationNumber = opts.sourceIncarnationNumber;
     var target = opts.target;
     var changes = opts.changes;
     var checksum = opts.checksum;
@@ -50,7 +51,8 @@ module.exports = function recvPingReq(opts, callback) {
         }
 
         callback(null, {
-            changes: ringpop.dissemination.issueChanges(checksum, source),
+            changes: ringpop.dissemination.issueAsReceiver(source,
+                sourceIncarnationNumber, checksum),
             pingStatus: isOk,
             target: target
         });

--- a/lib/swim/ping-req-sender.js
+++ b/lib/swim/ping-req-sender.js
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 'use strict';
+
 var safeParse = require('../util').safeParse;
 var TypedError = require('error/typed');
 
@@ -53,22 +54,6 @@ var PingReqPingError = TypedError({
     errMessage: null
 });
 
-function body(sender) {
-    return JSON.stringify({
-        checksum: sender.ring.membership.checksum,
-        changes: sender.ring.dissemination.issueChanges(),
-        source: sender.ring.whoami(),
-        target: sender.target.address
-    });
-}
-
-function sendOptions(sender)  {
-    return {
-        host: sender.member.address,
-        timeout: sender.ring.pingReqTimeout
-    };
-}
-
 function PingReqSender(ring, member, target, callback) {
     this.ring = ring;
     this.member = member;
@@ -79,7 +64,20 @@ function PingReqSender(ring, member, target, callback) {
 PingReqSender.prototype.send = function send() {
     var self = this;
 
-    this.ring.channel.send(sendOptions(this), '/protocol/ping-req', null, body(this), onSend);
+    var channelOpts = {
+        host: this.member.address,
+        timeout: this.ring.pingReqTimeout
+    };
+
+    var body = JSON.stringify({
+        checksum: this.ring.membership.checksum,
+        changes: this.ring.dissemination.issueAsSender(),
+        source: this.ring.whoami(),
+        sourceIncarnationNumber: this.ring.membership.getIncarnationNumber(),
+        target: this.target.address
+    });
+
+    this.ring.channel.send(channelOpts, '/protocol/ping-req', null, body, onSend);
 
     function onSend(err, res1, res2) {
         self.onPingReq(err, res1, res2);

--- a/lib/swim/ping-sender.js
+++ b/lib/swim/ping-sender.js
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 'use strict';
+
 var safeParse = require('../util').safeParse;
 
 function PingSender(ring, member, callback) {
@@ -58,17 +59,19 @@ PingSender.prototype.send = function send() {
         host: this.address,
         timeout: this.ring.pingTimeout
     };
-    var changes = this.ring.dissemination.issueChanges();
+    var changes = this.ring.dissemination.issueAsSender();
+
     var body = JSON.stringify({
         checksum: this.ring.membership.checksum,
         changes: changes,
-        source: this.ring.whoami()
+        source: this.ring.whoami(),
+        sourceIncarnationNumber: this.ring.membership.getIncarnationNumber()
     });
 
     this.ring.debugLog('ping send member=' + this.address + ' changes=' + JSON.stringify(changes), 'p');
 
     var self = this;
-    this.ring.channel.send(options, '/protocol/ping', null, body, function(err, res1, res2) {
+    this.ring.channel.send(options, '/protocol/ping', null, body, function onSend(err, res1, res2) {
         self.onPing(err, res1, res2);
     });
 };

--- a/lib/tchannel.js
+++ b/lib/tchannel.js
@@ -163,6 +163,9 @@ RingPopTChannel.prototype.protocolJoin = function (arg1, arg2, hostInfo, cb) {
 
 RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2);
+
+    // NOTE sourceIncarnationNumber is an optional argument. It was not present
+    // until after the v9.8.12 release.
     if (body === null || !body.source || !body.changes || !body.checksum) {
         return cb(new Error('need req body with source, changes, and checksum'));
     }
@@ -170,6 +173,7 @@ RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
     recvPing({
         ringpop: this.ringpop,
         source: body.source,
+        sourceIncarnationNumber: body.sourceIncarnationNumber,
         changes: body.changes,
         checksum: body.checksum
     }, function(err, res) {
@@ -179,6 +183,9 @@ RingPopTChannel.prototype.protocolPing = function (arg1, arg2, hostInfo, cb) {
 
 RingPopTChannel.prototype.protocolPingReq = function protocolPingReq(arg1, arg2, hostInfo, cb) {
     var body = safeParse(arg2);
+
+    // NOTE sourceIncarnationNumber is an optional argument. It was not present
+    // until after the v9.8.12 release.
     if (body === null || !body.source || !body.target || !body.changes || !body.checksum) {
         return cb(new Error('need req body with source, target, changes, and checksum'));
     }
@@ -186,6 +193,7 @@ RingPopTChannel.prototype.protocolPingReq = function protocolPingReq(arg1, arg2,
     recvPingReq({
         ringpop: this.ringpop,
         source: body.source,
+        sourceIncarnationNumber: body.sourceIncarnationNumber,
         target: body.target,
         changes: body.changes,
         checksum: body.checksum

--- a/main.js
+++ b/main.js
@@ -95,7 +95,7 @@ if (require.main === module) {
 
 function createLogger(name) {
     return {
-        debug: enrich('debug', 'log'),
+        debug: function noop() {},
         info: enrich('info', 'log'),
         warn: enrich('warn', 'error'),
         error: enrich('error', 'error')


### PR DESCRIPTION
…iginated from source

This is another optimization. Preventing issuing / piggybacking changes (in the dissemination component) to a node that created the change in the first place.

EDIT: I'll have to improve this by being a little more strict about which changes are filtered out. Filtering on source address alone is not entirely correct and might lead to interesting race conditions. Incarnation number of the member, and not just its address, should be evaluated too.