### PR TITLE
Index by address

### DIFF
--- a/benchmarks/find-member-by-address.js
+++ b/benchmarks/find-member-by-address.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var largeMembership = require('./large-membership.json');
+var Ringpop = require('../index.js');
+var Suite = require('benchmark').Suite;
+
+function reportPerformance(event) {
+    console.log(event.target.toString());
+}
+
+function benchFindOutOf1000() {
+    var ringpop;
+
+    var suite = new Suite();
+    suite.add('find one member out of 1000', benchThis);
+    suite.on('start', init);
+    suite.on('cycle', reportPerformance);
+    suite.run();
+
+    function benchThis() {
+        ringpop.membership.findMemberByAddress(largeMembership[0].address);
+    }
+
+    function init() {
+        ringpop = new Ringpop({
+            app: 'ringpop-bench',
+            hostPort: '127.0.0.1:3000'
+        });
+
+        ringpop.membership.update(largeMembership.slice(0, 1000));
+    }
+}
+
+benchFindOutOf1000();

--- a/lib/membership.js
+++ b/lib/membership.js
@@ -29,6 +29,7 @@ var util = require('util');
 function Membership(ringpop) {
     this.ringpop = ringpop;
     this.members = [];
+    this.membersByAddress = {};
     this.checksum = null;
 }
 
@@ -59,16 +60,7 @@ Membership.prototype.computeChecksum = function computeChecksum() {
 };
 
 Membership.prototype.findMemberByAddress = function findMemberByAddress(address) {
-    // TODO Index by address
-    for (var i = 0; i < this.members.length; i++) {
-        var member = this.members[i];
-
-        if (member.address === address) {
-            return member;
-        }
-    }
-
-    return null;
+    return this.membersByAddress[address];
 };
 
 Membership.prototype.generateChecksumString = function generateChecksumString() {
@@ -249,6 +241,7 @@ Membership.prototype.update = function update(changes) {
             }
 
             self.members.splice(self.getJoinPosition(), 0, member);
+            self.membersByAddress[member.address] = member;
         }
 
         member.status = update.status;

--- a/test/integration/swim-test.js
+++ b/test/integration/swim-test.js
@@ -190,7 +190,9 @@ testRingpopCluster({
     // Mutating all member addresses to make each of selected ping-req members
     // unreachable and therefore, the results of ping-req inconclusive.
     ringpop.membership.members.forEach(function eachMember(member) {
-        member.address += '001';
+        if (member.address !== unreachableMember.address) {
+            member.address += '001';
+        }
     });
 
     sendPingReq({


### PR DESCRIPTION
Trying to go piece-meal with my membership speed-ups. Quick fix to index members by their address for faster access:

```
Running 2 benchmark(s) for benchmarks/find-member-by-address.js
606d65c Benchmark for finding member by address 73,264 ops/sec
3731aff Index members by address 26,864,034 ops/sec
Benchmark complete!
```

@markyen @Raynos 