### PR TITLE
Add remove ring servers

### DIFF
--- a/benchmarks/add-remove-hashring.js
+++ b/benchmarks/add-remove-hashring.js
@@ -1,0 +1,88 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var largeMembership = require('./large-membership.json');
+var Ringpop = require('../index.js');
+var Suite = require('benchmark').Suite;
+
+var members = largeMembership.slice(0, 1000);
+var servers = members.map(function mapMember(member) {
+    return member.address;
+});
+
+function reportPerformance(event) {
+    console.log(event.target.toString());
+}
+
+function addRemoveIndividual() {
+    var ring;
+
+    var suite = new Suite();
+    suite.add('add/remove 1000 servers individually', benchThis);
+    suite.on('start', init);
+    suite.on('cycle', reportPerformance);
+    suite.run();
+
+    function benchThis() {
+        for (var i = 0; i < 1000; i++) {
+            ring.addServer(servers[i]);
+        }
+
+        for (var j = 0; j < 1000; j++) {
+            ring.removeServer(servers[j]);
+        }
+    }
+
+    function init() {
+        var ringpop = new Ringpop({
+            app: 'ringpop-bench',
+            hostPort: '127.0.0.1:3000'
+        });
+
+        ring = ringpop.ring;
+    }
+}
+
+function addRemoveBulk() {
+    var ring;
+
+    var suite = new Suite();
+    suite.add('add/remove 1000 servers in bulk', benchThis);
+    suite.on('start', init);
+    suite.on('cycle', reportPerformance);
+    suite.run();
+
+    function benchThis() {
+        ring.addRemoveServers(servers, servers);
+    }
+
+    function init() {
+        var ringpop = new Ringpop({
+            app: 'ringpop-bench',
+            hostPort: '127.0.0.1:3000'
+        });
+
+        ring = ringpop.ring;
+    }
+}
+
+addRemoveIndividual();
+addRemoveBulk();

--- a/lib/membership-update-listener.js
+++ b/lib/membership-update-listener.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var Member = require('./member.js');
+
+module.exports = function createListener(ringpop) {
+    return function onMembershipUpdated(updates) {
+        var serversToAdd = [];
+        var serversToRemove = [];
+
+        for (var i = 0; i < updates.length; i++) {
+            var update = updates[i];
+
+            ringpop.stat('increment', 'membership-update.' + (update.status || 'unknown'));
+
+            if (update.status === Member.Status.alive) {
+                serversToAdd.push(update.address);
+                ringpop.suspicion.stop(update);
+            } else if (update.status === Member.Status.suspect) {
+                ringpop.suspicion.start(update);
+            } else if (update.status === Member.Status.faulty) {
+                serversToRemove.push(update.address);
+                ringpop.suspicion.stop(update);
+            } else if (update.status === Member.Status.leave) {
+                serversToRemove.push(update.address);
+                ringpop.suspicion.stop(update);
+            }
+
+            ringpop.dissemination.recordChange(update);
+
+            ringpop.logger.debug('member updated', {
+                local: ringpop.whoami(),
+                address: update.address,
+                incarnationNumber: update.incarnationNumber,
+                status: update.status
+            });
+        }
+
+        // Must add/remove servers from ring in batch. There are
+        // efficiency gains when only having to compute the ring
+        // checksum once.
+        if (serversToAdd.length > 0 || serversToRemove.length > 0) {
+            var ringChanged = ringpop.ring.addRemoveServers(serversToAdd, serversToRemove);
+
+            if (ringChanged) {
+                ringpop.emit('ringChanged');
+            }
+        }
+
+        ringpop.membershipUpdateRollup.trackUpdates(updates);
+
+        ringpop.stat('gauge', 'num-members', ringpop.membership.members.length);
+        ringpop.stat('timing', 'updates', updates.length);
+
+        ringpop.emit('membershipChanged');
+        ringpop.emit('changed'); // Deprecated
+    };
+};

--- a/lib/ring.js
+++ b/lib/ring.js
@@ -34,22 +34,62 @@ function HashRing(options) {
 
 util.inherits(HashRing, EventEmitter);
 
-// TODO - error checking around adding a server that's already there
 // TODO - error checking from rbtree.insert
 HashRing.prototype.addServer = function addServer(name) {
     if (this.hasServer(name)) {
         return;
     }
 
-    this.servers[name] = true;
-
-    for (var i = 0; i < this.replicaPoints; i++) {
-        this.rbtree.insert(farmhash.hash32(name + i), name);
-    }
-
+    this.addServerReplicas(name);
     this.computeChecksum();
 
     this.emit('added', name);
+};
+
+HashRing.prototype.addServerReplicas = function addServerReplicas(server) {
+    // Assumes server has not been previously added.
+    this.servers[server] = true;
+
+    for (var i = 0; i < this.replicaPoints; i++) {
+        var hash = farmhash.hash32(server + i);
+        this.rbtree.insert(hash, server);
+    }
+};
+
+HashRing.prototype.addRemoveServers = function addRemoveServers(serversToAdd, serversToRemove) {
+    serversToAdd = serversToAdd || [];
+    serversToRemove = serversToRemove || [];
+
+    var addedServers = false;
+    var removedServers = false;
+
+    var server;
+
+    for (var i = 0; i < serversToAdd.length; i++) {
+        server = serversToAdd[i];
+
+        if (!this.hasServer(server)) {
+            this.addServerReplicas(server);
+            addedServers = true;
+        }
+    }
+
+    for (var j = 0; j < serversToRemove.length; j++) {
+        server = serversToRemove[j];
+
+        if (this.hasServer(server)) {
+            this.removeServerReplicas(server);
+            removedServers = true;
+        }
+    }
+
+    var ringChanged = addedServers || removedServers;
+
+    if (ringChanged) {
+        this.computeChecksum();
+    }
+
+    return ringChanged;
 };
 
 HashRing.prototype.computeChecksum = function computeChecksum() {
@@ -78,15 +118,20 @@ HashRing.prototype.removeServer = function removeServer(name) {
         return;
     }
 
-    delete this.servers[name];
-
-    for (var i = 0; i < this.replicaPoints; i++) {
-        this.rbtree.remove(farmhash.hash32(name + i), name);
-    }
-
+    this.removeServerReplicas(name);
     this.computeChecksum();
 
     this.emit('removed', name);
+};
+
+HashRing.prototype.removeServerReplicas = function removeServerReplicas(server) {
+    // Assumes server has been previously added.
+    delete this.servers[server];
+
+    for (var i = 0; i < this.replicaPoints; i++) {
+        var hash = farmhash.hash32(server + i);
+        this.rbtree.remove(hash, server);
+    }
 };
 
 HashRing.prototype.lookup = function lookup(str) {

--- a/test/ring-test.js
+++ b/test/ring-test.js
@@ -1,0 +1,76 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var _ = require('underscore');
+var HashRing = require('../lib/ring.js');
+var test = require('tape');
+
+function createServers(size) {
+    return _.times(size, function each(i) {
+        return '127.0.0.1:' + (3000 + i);
+    });
+}
+
+var servers = createServers(1000);
+
+test('has correct number of servers on add/remove', function t(assert) {
+    var ring = new HashRing();
+
+    ring.addRemoveServers(servers, null);
+    assert.equal(ring.getServerCount(), 1000, 'has 1000 servers');
+
+    ring.addRemoveServers(null, servers);
+    assert.equal(ring.getServerCount(), 0, 'has 0 servers');
+
+    ring.addRemoveServers(servers, servers);
+    assert.equal(ring.getServerCount(), 0, 'has 0 servers');
+
+    assert.end();
+});
+
+test('checksum computed only once', function t(assert) {
+    assert.plan(1);
+
+    var ring = new HashRing();
+    ring.on('checksumComputed', function onComputed() {
+        assert.pass('checksum computed');
+    });
+
+    ring.addRemoveServers(servers, servers);
+
+    assert.end();
+});
+
+test('1000 lookups', function t(assert) {
+    assert.plan(1000);
+
+    var ring = new HashRing();
+    ring.addRemoveServers(servers, null);
+
+    for (var i = 0; i < servers.length; i++) {
+        var server = servers[i];
+
+        assert.equal(ring.lookup(server + '0'), server,
+            'server hashes correctly');
+    }
+
+    assert.end();
+});


### PR DESCRIPTION
This is an effort to improve bootstrap/startup/join times. Bit of a performance boost with a slight refactor to take membership update handling out of the Ringpop prototype.

```
➜  ringpop git:(add-remove-ring-servers)        node benchmarks/add-remove-hashring.js
add/remove 1000 servers individually x 0.97 ops/sec ±2.57% (7 runs sampled)
add/remove 1000 servers in bulk x 3.80 ops/sec ±4.26% (14 runs sampled)
```