### PR TITLE
downgrade normal path message to debug

### DIFF
--- a/lib/swim/ping-req-sender.js
+++ b/lib/swim/ping-req-sender.js
@@ -178,7 +178,7 @@ module.exports = function sendPingReq(opts, callback) {
             // through implicit exchange of membership updates on
             // ping-req requests and responses.
             if (!err) {
-                ringpop.logger.info('ringpop ping-req determined member is reachable', {
+                ringpop.logger.debug('ringpop ping-req determined member is reachable', {
                     local: ringpop.whoami(),
                     errors: errors,
                     numErrors: errors.length,


### PR DESCRIPTION
This ping-req is reachable message is expected behaviour and
should not be an info(). It creates a bunch of un-needed
background noise.

r: @jwolski