### PR TITLE
Allow body limit to be specified for large object payloads

### DIFF
--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -84,7 +84,10 @@ proto.proxyReq = function proxyReq(opts) {
     var timeout = opts.timeout ?
         opts.timeout : this.ringpop.proxyReqTimeout;
 
-    body(req, res, { cache: true }, onBody);
+    body(req, res, {
+        cache: true,
+        limit: opts.bodyLimit
+    }, onBody);
 
     function onBody(err, rawBody) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "after": "^0.8.1",
     "benchmark": "^1.0.0",
+    "buffer-equal": "0.0.1",
     "cli-color": "^0.3.2",
     "commander": "^2.6.0",
     "coveralls": "^2.11.2",

--- a/test/integration/proxy-test.js
+++ b/test/integration/proxy-test.js
@@ -21,6 +21,7 @@
 
 var _ = require('underscore');
 var after = require('after');
+var bufferEqual = require('buffer-equal')
 var jsonBody = require('body/json');
 var test = require('tape');
 var TimeMock = require('time-mock');
@@ -1008,6 +1009,31 @@ test('send on destroyed channel not allowed', function t(assert) {
             assert.equal(resp.statusCode, 500);
             assert.ok(resp.body.indexOf(
                 'Channel was destroyed before forwarding attempt') >= 0);
+
+            cluster.destroy();
+            assert.end();
+        });
+    });
+});
+
+test('proxies big json', function t(assert) {
+    var buffer = new Buffer(1024 * 1024 * 1.5);
+    var bodyLimit = JSON.stringify(buffer).length;
+
+    var opts = {
+        bodyLimit: bodyLimit,
+        requestProxyMaxRetries: 0,
+    };
+
+    var cluster = allocCluster(opts, function onReady() {
+        cluster.request({
+            host: 'one', key: cluster.keys.two,
+            json: buffer,
+            bodyLimit: bodyLimit
+        }, function onResponse(err, resp) {
+            assert.ifError(err, 'no error occurred');
+            assert.ok(resp.body, 'response has a body');
+            assert.ok(bufferEqual(buffer, new Buffer(resp.body.payload)), 'buffers are equal');
 
             cluster.destroy();
             assert.end();

--- a/test/lib/alloc-cluster.js
+++ b/test/lib/alloc-cluster.js
@@ -44,9 +44,9 @@ function allocCluster(options, onReady) {
     var two = allocRingpop('two', options);
     var three = allocRingpop('three', options);
 
-    one.on('request', createHandler('one'));
-    two.on('request', createHandler('two'));
-    three.on('request', createHandler('three'));
+    one.on('request', createHandler('one', options));
+    two.on('request', createHandler('two', options));
+    three.on('request', createHandler('three', options));
 
     bootstrap([one, two, three], onReady);
 
@@ -87,7 +87,8 @@ function allocCluster(options, onReady) {
             timeout: opts.timeout,
             retrySchedule: opts.retrySchedule,
             endpoint: opts.endpoint,
-            maxRetries: opts.maxRetries
+            maxRetries: opts.maxRetries,
+            bodyLimit: opts.bodyLimit
         });
         if (handle) {
             cluster[host].emit('request', req, res);
@@ -102,10 +103,12 @@ function allocCluster(options, onReady) {
     }
 }
 
-function createServerHandler(name) {
+function createServerHandler(name, opts) {
     return function serverHandle(req, res) {
         if (req.headers['content-type'] === 'application/json') {
-            jsonBody(req, onBody);
+            jsonBody(req, null, {
+                limit: opts.bodyLimit
+            }, onBody);
         } else {
             onBody(null, undefined);
         }


### PR DESCRIPTION
Resurrecting an old branch that was never put into play. Allows custom limit to body that is proxied across tchannel. By default, limit is 1MB. Lei needs MORE MBs.

This is broken against ringpop master (w/ tchannel v2), but not against latest stable, v9.8.17.

@leizha 