### PR TITLE
Stash join responses

### DIFF
--- a/benchmarks/join-response-merge.js
+++ b/benchmarks/join-response-merge.js
@@ -27,11 +27,11 @@ function reportPerformance(event) {
     console.log(event.target.toString());
 }
 
-function benchMerge() {
+function benchMerge(title, checksum) {
     var responses = [];
 
     var suite = new Suite();
-    suite.add('merge 3 responses of 1000 members', benchThis);
+    suite.add(title, benchThis);
     suite.on('start', init);
     suite.on('cycle', reportPerformance);
     suite.run();
@@ -45,10 +45,20 @@ function benchMerge() {
 
         for (var i = 0; i < 3; i++) {
             responses.push({
-                members: members1k
+                members: members1k,
+                checksum: checksum
             });
         }
     }
 }
 
-benchMerge();
+function benchMergeNoChecksum() {
+    benchMerge('merge 3 responses of 1000 members with no checksum');
+}
+
+function benchMergeSameChecksum() {
+    benchMerge('merge 3 responses of 1000 members with same checksum', 123456789);
+}
+
+benchMergeNoChecksum();
+benchMergeSameChecksum();

--- a/benchmarks/join-response-merge.js
+++ b/benchmarks/join-response-merge.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var largeMembership = require('./large-membership.json');
+var mergeJoinResponses = require('../lib/swim/join-response-merge.js');
+var Suite = require('benchmark').Suite;
+
+function reportPerformance(event) {
+    console.log(event.target.toString());
+}
+
+function benchMerge() {
+    var responses = [];
+
+    var suite = new Suite();
+    suite.add('merge 3 responses of 1000 members', benchThis);
+    suite.on('start', init);
+    suite.on('cycle', reportPerformance);
+    suite.run();
+
+    function benchThis() {
+        mergeJoinResponses(responses);
+    }
+
+    function init() {
+        var members1k = largeMembership.slice(0, 1000);
+
+        for (var i = 0; i < 3; i++) {
+            responses.push({
+                members: members1k
+            });
+        }
+    }
+}
+
+benchMerge();

--- a/lib/member.js
+++ b/lib/member.js
@@ -19,8 +19,10 @@
 // THE SOFTWARE.
 'use strict';
 
-function Member() {
-
+function Member(address, status, incarnationNumber) {
+    this.address = address;
+    this.status = status;
+    this.incarnationNumber = incarnationNumber;
 }
 
 Member.Status = {

--- a/lib/swim/join-recvr.js
+++ b/lib/swim/join-recvr.js
@@ -92,6 +92,7 @@ module.exports = function recvJoin(opts, callback) {
     callback(null, {
         app: ringpop.app,
         coordinator: ringpop.whoami(),
-        membership: ringpop.dissemination.fullSync()
+        membership: ringpop.dissemination.fullSync(),
+        membershipChecksum: ringpop.membership.checksum
     });
 };

--- a/lib/swim/join-response-merge.js
+++ b/lib/swim/join-response-merge.js
@@ -19,9 +19,29 @@
 // THE SOFTWARE.
 'use strict';
 
+function hasSameChecksums(joinResponses) {
+    var lastChecksum = -1;
+
+    for (var i = 0; i < joinResponses.length; i++) {
+        var response = joinResponses[i];
+
+        if (!response.checksum || (lastChecksum !== -1 && lastChecksum !== response.checksum)) {
+            return false;
+        }
+
+        lastChecksum = response.checksum;
+    }
+
+    return true;
+}
+
 function mergeJoinResponses(joinResponses) {
     if (!Array.isArray(joinResponses) || joinResponses.length === 0) {
         return [];
+    }
+
+    if (hasSameChecksums(joinResponses)) {
+        return joinResponses[0].members;
     }
 
     var mergeIndex = {};

--- a/lib/swim/join-response-merge.js
+++ b/lib/swim/join-response-merge.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+function mergeJoinResponses(joinResponses) {
+    if (!Array.isArray(joinResponses) || joinResponses.length === 0) {
+        return [];
+    }
+
+    var mergeIndex = {};
+
+    for (var i = 0; i < joinResponses.length; i++) {
+        var members = joinResponses[i].members;
+
+        for (var j = 0; j < members.length; j++) {
+            var member = members[j];
+
+            var indexVal = mergeIndex[member.address];
+
+            if (!indexVal || indexVal.incarnationNumber < member.incarnationNumber) {
+                mergeIndex[member.address] = member;
+            }
+        }
+    }
+
+    var indexKeys = Object.keys(mergeIndex);
+    var updates = new Array(indexKeys.length);
+
+    for (i = 0; i < indexKeys.length; i++) {
+        updates[i] = mergeIndex[indexKeys[i]];
+    }
+
+    return updates;
+}
+
+module.exports = mergeJoinResponses;

--- a/lib/swim/join-sender.js
+++ b/lib/swim/join-sender.js
@@ -22,6 +22,7 @@
 var captureHost = require('../util.js').captureHost;
 var errors = require('../errors.js');
 var isEmptyArray = require('../util.js').isEmptyArray;
+var mergeJoinResponses = require('./join-response-merge.js');
 var numOrDefault = require('../util.js').numOrDefault;
 var safeParse = require('../util.js').safeParse;
 var TypedError = require('error/typed');
@@ -144,6 +145,10 @@ function JoinCluster(opts) {
     // exceeded.
     this.roundPotentialNodes = null;
     this.roundPreferredNodes = null;
+
+    // Changes received by other nodes will be aggregated and
+    // applied once the join process is complete.
+    this.joinResponses = [];
 }
 
 // Potential nodes are those that are not this instance of ringpop.
@@ -248,6 +253,14 @@ JoinCluster.prototype.join = function join(callback) {
 
         if (numJoined >= self.joinSize) {
             var joinTime = Date.now() - startTime;
+
+            var updates = mergeJoinResponses(self.joinResponses);
+
+            // Update membership only once, when join is complete and successful.
+            self.ringpop.membership.update(updates);
+
+            // No need to keep this data hanging around.
+            self.joinResponses = null;
 
             self.ringpop.stat('timing', 'join', joinTime);
             self.ringpop.stat('increment', 'join.complete');
@@ -416,8 +429,15 @@ JoinCluster.prototype.joinNode = function joinNode(node, callback) {
 
                     var bodyObj = safeParse(arg3.toString());
 
-                    if (bodyObj) {
-                        self.ringpop.membership.update(bodyObj.membership);
+                    // Verify that `joinResponses` is not null. It is set
+                    // to null upon completion of the join process. There may,
+                    // however, be in-flight /protocol/join requests that have
+                    // yet to complete.
+                    if (bodyObj && self.joinResponses !== null) {
+                        self.joinResponses.push({
+                            checksum: bodyObj.membershipChecksum,
+                            members: bodyObj.membership
+                        });
                     }
 
                     callback(null, node);

--- a/test/join-response-merge-test.js
+++ b/test/join-response-merge-test.js
@@ -1,0 +1,122 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var Member = require('../lib/member.js');
+var mergeJoinResponses = require('../lib/swim/join-response-merge.js');
+var test = require('tape');
+
+test('no responses results in empty array', function t(assert) {
+    var result = mergeJoinResponses(null);
+    assert.deepEqual(result, [], 'empty array');
+
+    result = mergeJoinResponses([]);
+    assert.deepEqual(result, [], 'empty array');
+
+    assert.end();
+});
+
+test('responses with same checksum uses first response', function t(assert) {
+    var responseCounter = 0;
+    var firstResponse = createResponse();
+    var responses = [
+        firstResponse,
+        createResponse(),
+        createResponse()
+    ];
+
+    var result = mergeJoinResponses(responses);
+    assert.deepEqual(result, firstResponse.members, 'takes first response');
+
+    assert.end();
+
+    function createResponse() {
+        return {
+            checksum: 123456789,
+            members: [{
+                address: '127.0.0.1:' + (3000 + (responseCounter++)),
+                status: 'alive',
+                incarnationNumber: Date.now()
+            }]
+        };
+    }
+});
+
+test('merges responses and takes those updates with higher incarnation numbers', function t(assert) {
+    var firstResponse = createResponse(123456789, [
+        new Member('127.0.0.1:3000', 'suspect', 1),
+        new Member('127.0.0.1:3001', 'alive', 2)
+    ]);
+    var secondResponse = createResponse(23456789, [
+        new Member('127.0.0.1:3000', 'alive', 2),
+        new Member('127.0.0.1:3001', 'suspect', 1),
+        new Member('127.0.0.1:3002', 'faulty', 1)
+    ]);
+    var mergedMembers = [
+        new Member('127.0.0.1:3000', 'alive', 2),
+        new Member('127.0.0.1:3001', 'alive', 2),
+        new Member('127.0.0.1:3002', 'faulty', 1),
+    ];
+
+    var result = mergeJoinResponses([firstResponse, secondResponse]);
+    assert.deepEqual(result, mergedMembers, 'members are merged');
+
+    assert.end();
+
+    function createResponse(checksum, members) {
+        return {
+            checksum: checksum,
+            members: members
+        };
+    }
+});
+
+test('merges responses when checksums are null', function t(assert) {
+    var firstResponse = createResponse(null, [
+        new Member('127.0.0.1:3000', 'suspect', 1),
+        new Member('127.0.0.1:3001', 'alive', 2)
+    ]);
+    var secondResponse = createResponse(null, [
+        new Member('127.0.0.1:3000', 'alive', 2),
+        new Member('127.0.0.1:3001', 'suspect', 1),
+        new Member('127.0.0.1:3002', 'faulty', 1)
+    ]);
+    var mergedMembers = [
+        new Member('127.0.0.1:3000', 'alive', 2),
+        new Member('127.0.0.1:3001', 'alive', 2),
+        new Member('127.0.0.1:3002', 'faulty', 1)
+    ];
+
+    var result = mergeJoinResponses([firstResponse, secondResponse]);
+    assert.deepEqual(result, mergedMembers, 'members are merged');
+
+    firstResponse.checksum = 123456789;
+    result = mergeJoinResponses([firstResponse, secondResponse]);
+    assert.deepEqual(result, mergedMembers, 'members are merged');
+
+    assert.end();
+
+    function createResponse(checksum, members) {
+        return {
+            checksum: checksum,
+            members: members
+        };
+    }
+});


### PR DESCRIPTION
This is a pretty significant improvement to the join process, especially when clusters are large (1k+ nodes). Rather than applying individual membership updates for each join response, they are aggregated, merged and applied once after the number of required nodes have been joined. This will reduce a lot of duplicate effort which typically causes significant CPU burn.