### PR TITLE
Remove call to membership.update() in ping response. It was redundant

### DIFF
--- a/index.js
+++ b/index.js
@@ -452,11 +452,10 @@ RingPop.prototype.pingMemberNow = function pingMemberNow(callback) {
     sendPing({
         ringpop: self,
         target: member
-    }, function(isOk, body) {
+    }, function(isOk) {
         self.stat('timing', 'ping', start);
         if (isOk) {
             self.isPinging = false;
-            self.membership.update(body.changes);
             return callback();
         }
 


### PR DESCRIPTION
Quick fix. Call to `membership.update()` when ping response is received was redundant -- already done within `ping-sender.js`. This hints at the fact that the `pingMemberNow()` hanging off of the Ringpop prototype shouldn't even exist (just adds complexity and fragmentation of logic) and folded into the logic of PingSender... which is a refactor that'll be done next.