### PR TITLE
Wieger tick cluster go

### DIFF
--- a/scripts/tick-cluster.js
+++ b/scripts/tick-cluster.js
@@ -581,12 +581,12 @@ if (!programPath) {
     process.exit(1);
 }
 
-if(!fs.existsSync(programPath)) {
+if (!fs.existsSync(programPath)) {
     console.log('Error: program ' + programPath + ' does not exist. Check path');
     process.exit(1);
 }
 
-if(isNaN(procsToStart)) {
+if (isNaN(procsToStart)) {
     console.log('Error: number of processes to start is not an integer');
     process.exit(1);
 }


### PR DESCRIPTION
- spawn generic ringpop processes (binaries or via interpreter). e.g.
```
tickcluster 10 path/to/binary/testpop
tickcluster 10 -i node path/to/main.js
tickcluster 10 --interpreter node path/to/main.js
```
where tickcluster is an alias for `alias tickcluster='node ~/code/ringpop/scripts/tick-cluster.js'`.

- Adds grid mode view. Press z to activate

- Also removed a bug where tickcluster crashes if you request status (type 's') directly after starting the cluster.

@jwolski, @danielheller 