### PR TITLE
Update architecture_design.md

### DIFF
--- a/docs/architecture_design.md
+++ b/docs/architecture_design.md
@@ -87,7 +87,7 @@ Content coming soon...
 ### TChannel
 Content coming soon...
 
-[TChannel] (https://github.com/uber/tchannel) is a network multiplexing and framing protocol for RPC. Some of the characteristics of TChannel:
+[TChannel](https://github.com/uber/tchannel) is a network multiplexing and framing protocol for RPC. Some of the characteristics of TChannel:
 - Easy to implement in multiple languages, especially JavaScript and Python.
 - High performance forwarding path. Intermediaries can make a forwarding decision quickly.
 - Request/response model with out-of-order responses. Slow request will not block subsequent faster requests at head of line.


### PR DESCRIPTION
Remove an extra space in a link.  This wasn't showing up as a link on readthedocs