### PR TITLE
Implement tchannel forwarding for node.

### DIFF
--- a/examples/tchannel-forwarding.js
+++ b/examples/tchannel-forwarding.js
@@ -1,0 +1,93 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var TChannel = require('tchannel');
+var Ringpop = require('../index.js');
+var RingpopHandler = require('../ringpop-handler.js');
+
+function App(options) {
+    if (!(this instanceof App)) {
+        return new App(options);
+    }
+
+    var self = this;
+
+    self.name = options.name;
+    self.port = options.port;
+    self.ringpopHosts = options.ringpopHosts;
+
+    self.channel = TChannel();
+    self.ringpop = Ringpop({
+        app: 'app',
+        hostPort: '127.0.0.1:' + self.port,
+        channel: self.channel.makeSubChannel({
+            serviceName: 'ringpop'
+        })
+    });
+
+    self.appChannel = self.channel.makeSubChannel({
+        serviceName: 'app'
+    });
+    self.appChannel.handler = RingpopHandler({
+        channel: self.appChannel,
+        ringpop: self.ringpop,
+        logger: self.channel.logger,
+        realHandler: self.appChannel.handler
+    });
+
+    self.appChannel.register('hello', function hello(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
+        res.sendOk('', 'hello from ' + self.name + ' for ' + req.headers.sk);
+    });
+
+    self.ringpop.setupChannel();
+}
+
+App.prototype.bootstrap = function bootstrap(cb) {
+    var self = this;
+
+    self.channel.listen(self.port, '127.0.0.1', onListen);
+
+    function onListen() {
+        self.ringpop.bootstrap(self.ringpopHosts, onBootstrap);
+    }
+
+    function onBootstrap() {
+        console.log('app: ' + self.name + ' listening on ' +
+            self.channel.address().port);
+    }
+};
+
+if (require.main === module) {
+    var app1 = App({
+        name: 'app1',
+        port: 4040,
+        ringpopHosts: ['127.0.0.1:4040', '127.0.0.1:4041']
+    });
+    var app2 = App({
+        name: 'app2',
+        port: 4041,
+        ringpopHosts: ['127.0.0.1:4040', '127.0.0.1:4041']
+    });
+
+    app1.bootstrap();
+    app2.bootstrap();
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "opn": "^1.0.1",
     "pre-commit": "^0.0.9",
     "tape": "^3.0.3",
-    "tchannel": "^2.4.6",
+    "tape-cluster": "2.1.0",
+    "tchannel": "^2.5.1",
     "time-mock": "^0.1.2",
     "tryit": "^1.0.1",
     "uber-licence": "^1.1.0"

--- a/ringpop-handler.js
+++ b/ringpop-handler.js
@@ -84,7 +84,8 @@ RingpopHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
             serviceName: req.serviceName,
             endpoint: req.endpoint,
             callerName: req.headers.cn,
-            headers: req.headers
+            headers: req.headers,
+            local: self.ringpop.whoami()
         });
         return buildRes().sendError(
             'BadRequest',

--- a/ringpop-handler.js
+++ b/ringpop-handler.js
@@ -1,0 +1,108 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+
+var RelayRequest = require('tchannel/relay_handler').RelayRequest;
+
+module.exports = RingpopHandler;
+
+function RingpopHandler(options) {
+    /*eslint max-statements: [2, 25]*/
+    if (!(this instanceof RingpopHandler)) {
+        return new RingpopHandler(options);
+    }
+
+    var self = this;
+
+    self.realHandler = options.realHandler;
+    assert(
+        typeof self.realHandler === 'object',
+        'expected options.realHandler'
+    );
+
+    self.ringpop = options.ringpop;
+    assert(typeof self.ringpop === 'object', 'expected options.ringpop');
+
+    self.channel = options.channel;
+    assert(typeof self.channel === 'object', 'expected options.channel');
+
+    self.logger = options.logger;
+    assert(typeof self.logger === 'object', 'expected options.logger');
+
+    // Blacklist of methods that will not be 'auto-sharded' but instead will
+    // be passed thru to the handler. Object mapping names to boolean.
+    self.blacklist = options.blacklist || null;
+    if (self.blacklist) {
+        assert(
+            typeof self.blacklist === 'object',
+            'expected options.blacklist to be an object'
+        );
+
+        var blackListKeys = Object.keys(self.blacklist);
+        for (var i = 0; i < blackListKeys.length; i++) {
+            var key = blackListKeys[i];
+            assert(typeof self.blacklist[key] === 'boolean',
+                'expected options.blacklist item to be boolean'
+            );
+        }
+    }
+}
+
+RingpopHandler.prototype.type = 'tchannel.endpoint-handler';
+
+RingpopHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
+    var self = this;
+
+    if (self.blacklist && self.blacklist[req.endpoint]) {
+        return self.realHandler.handleRequest(req, buildRes);
+    }
+
+    var shardKey = req.headers.sk;
+    if (!shardKey) {
+        self.logger.warn('Ringpop got request without a shardKey', {
+            socketRemoteAddr: req.remoteAddr,
+            serviceName: req.serviceName,
+            endpoint: req.endpoint,
+            callerName: req.headers.cn,
+            headers: req.headers
+        });
+        return buildRes().sendError(
+            'BadRequest',
+            '[ringpop] Request does not have sk header set'
+        );
+    }
+
+    var dest = self.ringpop.lookup(shardKey);
+    if (self.ringpop.whoami() === dest) {
+        return self.realHandler.handleRequest(req, buildRes);
+    }
+
+    var outreq = new RelayRequest(self.channel, req, buildRes);
+    outreq.createOutRequest(dest);
+};
+
+RingpopHandler.prototype.register = function register(arg1, fn) {
+    var self = this;
+
+    self.realHandler.register(arg1, fn);
+};

--- a/ringpop-handler.js
+++ b/ringpop-handler.js
@@ -93,13 +93,20 @@ RingpopHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
         );
     }
 
-    var dest = self.ringpop.lookup(shardKey);
+    var dest = self.resolveHost(shardKey);
     if (self.ringpop.whoami() === dest) {
         return self.realHandler.handleRequest(req, buildRes);
     }
 
     var outreq = new RelayRequest(self.channel, req, buildRes);
     outreq.createOutRequest(dest);
+};
+
+RingpopHandler.prototype.resolveHost =
+function resolveHost(shardKey) {
+    var self = this;
+
+    return self.ringpop.lookup(shardKey);
 };
 
 RingpopHandler.prototype.register = function register(arg1, fn) {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -22,3 +22,5 @@
 require('./join-test.js');
 require('./proxy-test.js');
 require('./ring-test.js');
+require('./swim-test.js');
+require('./tchannel-proxy-test.js');

--- a/test/integration/proxy-test.js
+++ b/test/integration/proxy-test.js
@@ -978,7 +978,8 @@ test('handle tchannel failures', function t(assert) {
         setTimeout(function onTimer() {
             var name = cluster.two.channel.hostPort;
             var peer = cluster.one.channel.peers.get(name);
-            var conn = peer.connections[0]; // the "out" one
+
+            var conn = peer.connections[1]; // the "in" one
             conn.socket.destroy();
         }, 100);
     });

--- a/test/integration/tchannel-proxy-test.js
+++ b/test/integration/tchannel-proxy-test.js
@@ -83,3 +83,67 @@ TChannelProxyCluster.test('RingpopHandler for two', {
         assert.end();
     }
 });
+
+TChannelProxyCluster.test('RingpopHandler for two', {
+    size: 3
+}, function t(cluster, assert) {
+    cluster.client.request({
+        serviceName: cluster.serviceName,
+        headers: {
+            sk: cluster.keys.two
+        },
+        host: cluster.hosts.one
+    }).send('ping', '', '', onResponse);
+
+    function onResponse(err, resp, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.ok(resp.ok);
+        assert.equal(arg3.toString(), 'ping from two');
+
+        assert.end();
+    }
+});
+
+TChannelProxyCluster.test('RingpopHandler blacklist', {
+    size: 3,
+    blacklist: {
+        'ping': true
+    }
+}, function t(cluster, assert) {
+    cluster.client.request({
+        serviceName: cluster.serviceName,
+        headers: {
+            sk: cluster.keys.two
+        },
+        host: cluster.hosts.one
+    }).send('ping', '', '', onResponse);
+
+    function onResponse(err, resp, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.ok(resp.ok);
+        assert.equal(arg3.toString(), 'ping from one');
+
+        assert.end();
+    }
+});
+
+TChannelProxyCluster.test('RingpopHandler bad request', {
+    size: 3
+}, function t(cluster, assert) {
+    cluster.client.request({
+        serviceName: cluster.serviceName,
+        host: cluster.hosts.one
+    }).send('ping', '', '', onResponse);
+
+    function onResponse(err, resp, arg2, arg3) {
+        assert.ok(err);
+
+        assert.equal(err.codeName, 'BadRequest');
+        assert.equal(err.message,
+            '[ringpop] Request does not have sk header set');
+
+        assert.end();
+    }
+});

--- a/test/integration/tchannel-proxy-test.js
+++ b/test/integration/tchannel-proxy-test.js
@@ -1,0 +1,85 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var TChannelProxyCluster = require('../lib/tchannel-proxy-cluster.js');
+
+TChannelProxyCluster.test('RingpopHandler proxies', {
+    size: 3
+}, function t(cluster, assert) {
+    cluster.client.request({
+        serviceName: cluster.serviceName,
+        headers: {
+            sk: cluster.keys.one
+        },
+        host: cluster.hosts.one
+    }).send('ping', '', '', onResponse);
+
+    function onResponse(err, resp, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.ok(resp.ok);
+        assert.equal(arg3.toString(), 'ping from one');
+
+        assert.end();
+    }
+});
+
+TChannelProxyCluster.test('RingpopHandler to other node', {
+    size: 3
+}, function t(cluster, assert) {
+    cluster.client.request({
+        serviceName: cluster.serviceName,
+        headers: {
+            sk: cluster.keys.one
+        },
+        host: cluster.hosts.three
+    }).send('ping', '', '', onResponse);
+
+    function onResponse(err, resp, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.ok(resp.ok);
+        assert.equal(arg3.toString(), 'ping from one');
+
+        assert.end();
+    }
+});
+
+TChannelProxyCluster.test('RingpopHandler for two', {
+    size: 3
+}, function t(cluster, assert) {
+    cluster.client.request({
+        serviceName: cluster.serviceName,
+        headers: {
+            sk: cluster.keys.two
+        },
+        host: cluster.hosts.one
+    }).send('ping', '', '', onResponse);
+
+    function onResponse(err, resp, arg2, arg3) {
+        assert.ifError(err);
+
+        assert.ok(resp.ok);
+        assert.equal(arg3.toString(), 'ping from two');
+
+        assert.end();
+    }
+});

--- a/test/lib/alloc-ringpop.js
+++ b/test/lib/alloc-ringpop.js
@@ -64,8 +64,8 @@ function allocRingpop(name, options) {
 }
 
 function semiRandPort() {
-    var base = 20000;
-    var rand = Math.floor(Math.random() * 20000);
+    var base = 10000;
+    var rand = Math.floor(Math.random() * 10000);
 
     return base + rand;
 }

--- a/test/lib/bootstrap.js
+++ b/test/lib/bootstrap.js
@@ -34,13 +34,13 @@ function bootstrap(ringpops, done) {
         var host = hostPortParts[0];
         var port = Number(hostPortParts[1]);
 
-        r.channel.on('listening', function onListening() {
-            r.channel.removeListener('listening', onListening);
+        r.channel.topChannel.on('listening', function onListening() {
+            r.channel.topChannel.removeListener('listening', onListening);
             r.once('ready', onReady);
             r.bootstrap(hosts.slice());
         });
 
-        r.channel.listen(port, host);
+        r.channel.topChannel.listen(port, host);
     });
 
     function onReady() {

--- a/test/lib/tchannel-proxy-cluster.js
+++ b/test/lib/tchannel-proxy-cluster.js
@@ -39,6 +39,7 @@ function TChannelProxyCluster(options) {
     var self = this;
 
     self.size = options.size;
+    self.blacklist = options.blacklist;
     self.serviceName = options.serviceName || 'app';
 
     self.keys = null;
@@ -108,6 +109,7 @@ function setupHandler(name, ringpop) {
         realHandler: realHandler,
         channel: channel,
         ringpop: ringpop,
+        blacklist: self.blacklist,
         logger: ringpop.logger
     });
 

--- a/test/lib/tchannel-proxy-cluster.js
+++ b/test/lib/tchannel-proxy-cluster.js
@@ -1,0 +1,128 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var tape = require('tape');
+var tapeCluster = require('tape-cluster');
+var TChannel = require('tchannel');
+var parallel = require('async').parallel;
+
+var RingpopHandler = require('../../ringpop-handler.js');
+var allocCluster = require('./alloc-cluster.js');
+
+TChannelProxyCluster.test = tapeCluster(tape, TChannelProxyCluster);
+
+module.exports = TChannelProxyCluster;
+
+function TChannelProxyCluster(options) {
+    if (!(this instanceof TChannelProxyCluster)) {
+        return new TChannelProxyCluster(options);
+    }
+
+    var self = this;
+
+    self.size = options.size;
+    self.serviceName = options.serviceName || 'app';
+
+    self.keys = null;
+    self.hosts = null;
+    self.cluster = null;
+    self.clientRootChannel = null;
+    self.client = null;
+}
+
+TChannelProxyCluster.prototype.bootstrap = function bootstrap(cb) {
+    var self = this;
+
+    self.cluster = allocCluster(onCluster);
+    self.keys = self.cluster.keys;
+    self.clientRootChannel = TChannel();
+
+    self.client = self.clientRootChannel.makeSubChannel({
+        serviceName: self.serviceName,
+        requestDefaults: {
+            headers: {
+                cn: 'client-app',
+                as: 'raw'
+            },
+            hasNoParent: true
+        }
+    });
+
+    function onCluster() {
+        self.hosts = {
+            one: self.cluster.one.hostPort,
+            two: self.cluster.two.hostPort,
+            three: self.cluster.three.hostPort
+        };
+
+        self.setupHandler('one', self.cluster.one);
+        self.setupHandler('two', self.cluster.two);
+        self.setupHandler('three', self.cluster.three);
+        self.client.listen(0, '127.0.0.1', onListen);
+    }
+
+    function onListen() {
+        parallel([
+            self.client.waitForIdentified.bind(self.client, {
+                host: self.hosts.one
+            }),
+            self.client.waitForIdentified.bind(self.client, {
+                host: self.hosts.two
+            }),
+            self.client.waitForIdentified.bind(self.client, {
+                host: self.hosts.three
+            })
+        ], cb);
+    }
+};
+
+TChannelProxyCluster.prototype.setupHandler =
+function setupHandler(name, ringpop) {
+    var self = this;
+
+    var channel = ringpop.channel;
+    var subChannel = channel.topChannel.makeSubChannel({
+        serviceName: self.serviceName
+    });
+
+    var realHandler = subChannel.handler;
+    subChannel.handler = RingpopHandler({
+        realHandler: realHandler,
+        channel: channel,
+        ringpop: ringpop,
+        logger: ringpop.logger
+    });
+
+    subChannel.register('ping', ping);
+
+    function ping(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
+        res.sendOk(arg2, 'ping from ' + name);
+    }
+};
+
+TChannelProxyCluster.prototype.close = function close(cb) {
+    var self = this;
+
+    self.cluster.destroy();
+    self.clientRootChannel.close();
+    cb();
+};


### PR DESCRIPTION
This is an implementation of ringpop forwarding for
tchannel v2.

You can see the expected use case in the examples.

TODO: 

 - [ ] ringpop forwarding stats
 - [ ] early abort on checksum failure
 - [ ] retries?

I suspect we do not want retries in RingpopHandler and
should rely on retries in either the client or in hyperbahn
itself. We currently have retries in HTTP forwarding because
we dont have retries in HTTP clients..

Adding early abort on checksum failure is possible but I should
probably carve out another transport header for it. Maybe
add "server checksum" or "sc" as a transport header.

If we do not implement early abort on checksum failure then
a request could in theory get forwarded forever because
infinite divergence or flappy-ness. Of course it will timeout
in tchannel itself but it would be nicer to have a UnexpectedError
telling you that its ringpop divergence instead.

This code is already used in two applications at uber so it's
time we add it to ringpop core itself.

r: @jwolski @jcorbin @benfleis
cc: @rssathe @rf