### PR TITLE
Close all peer connections to trigger socket closed response

### DIFF
--- a/test/integration/proxy-test.js
+++ b/test/integration/proxy-test.js
@@ -979,8 +979,12 @@ test('handle tchannel failures', function t(assert) {
             var name = cluster.two.channel.hostPort;
             var peer = cluster.one.channel.peers.get(name);
 
-            var conn = peer.connections[1]; // the "in" one
-            conn.socket.destroy();
+            // Kill all connections. This will trigger the
+            // socket closed response we're asserting on
+            // above.
+            peer.connections.forEach(function each(conn) {
+                conn.socket.destroy();
+            });
         }, 100);
     });
 });


### PR DESCRIPTION
This is a fix for the test that broke in between tchannel (as a devDependency) between 2.5.1 and 2.6.1. I confirmed with @jcorbin that the tchannel commit that git-bisect pointed at was intentional. Thankfully, this "problematic" commit neither breaks Ringpop nor TChannel, just a test (that was highly coupled to existing TChannel behavior). This closes all peer connections and induces a closed socket and makes the test pass.

@benfleis @danielheller @CorgiMan @Raynos 