### PR TITLE
RingpopHandler: update RelayRequest usage for TChannel 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pre-commit": "^0.0.9",
     "tape": "^3.0.3",
     "tape-cluster": "2.1.0",
-    "tchannel": "^2.5.1",
+    "tchannel": "^2.7.0",
     "time-mock": "^0.1.2",
     "tryit": "^1.0.1",
     "uber-licence": "^1.1.0"

--- a/ringpop-handler.js
+++ b/ringpop-handler.js
@@ -98,8 +98,9 @@ RingpopHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
         return self.realHandler.handleRequest(req, buildRes);
     }
 
-    var outreq = new RelayRequest(self.channel, req, buildRes);
-    outreq.createOutRequest(dest);
+    var peer = self.channel.peers.add(dest);
+    var outreq = new RelayRequest(self.channel, peer, req, buildRes);
+    outreq.createOutRequest();
 };
 
 RingpopHandler.prototype.resolveHost =


### PR DESCRIPTION
Update to work past https://github.com/uber/tchannel/pull/1222 which shipped in TChannel 2.7.0.

r @jwolski 