### PR TITLE
add a skipLookupOnRetry request opt

### DIFF
--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -115,7 +115,8 @@ proto.proxyReq = function proxyReq(opts) {
             },
             retries: {
                 max: numOrDefault(maxRetries, self.maxRetries),
-                schedule: retrySchedule || self.retrySchedule
+                schedule: retrySchedule || self.retrySchedule,
+                skipLookup: opts.skipLookupOnRetry
             }
         }, function () {
             var args = arguments;

--- a/lib/request-proxy/send.js
+++ b/lib/request-proxy/send.js
@@ -78,6 +78,7 @@ function RequestProxySend(opts) {
     this.retrySchedule = this.retries.schedule || RETRY_SCHEDULE;
     this.maxRetries = numOrDefault(this.retries.max, this.retrySchedule.length);
     this.maxRetryTimeout = this.retrySchedule[this.retrySchedule.length - 1] * 1000;
+    this.skipLookupOnRetry = this.retries.skipLookup;
 
     this.destinations = [this.channelOpts.host];
     this.errors = [];
@@ -105,8 +106,9 @@ RequestProxySend.prototype.abortOnKeyDivergence = function abortOnKeyDivergence(
 RequestProxySend.prototype.attemptRetry = function attemptRetry(callback) {
     this.numRetries++;
 
+    var dests = this.skipLookupOnRetry ? [ this.channelOpts.host ] : this.lookupKeys(this.keys);
+
     // TODO Support this case too
-    var dests = this.lookupKeys(this.keys);
     if (dests.length > 1) {
         this.abortOnKeyDivergence(dests, callback);
         return;

--- a/test/request_proxy_test.js
+++ b/test/request_proxy_test.js
@@ -82,3 +82,36 @@ test('request proxy emits head', function t(assert) {
     });
     proxy.handleRequest(headExpected, null, mocks.noop);
 });
+
+test('request proxy passes down skipLookupOnRetry correctly', function t(assert) {
+    assert.plan(2);
+
+    var key = 'donaldduck';
+    var dest = 'disneyworld';
+
+    var proxy = createRequestProxy();
+    var ringpop = proxy.ringpop;
+    ringpop.requestProxy = proxy;
+    ringpop.channel.request = function(/* options */) {
+        return {
+            send: function() {
+                process.nextTick(function () {
+                    assert.equals(proxy.sends.length, 1, '1 send');
+                    assert.equals(proxy.sends[0].skipLookupOnRetry, true, 'skipLookupOnRetry passed down');
+
+                    ringpop.destroy();
+                    assert.end();
+                });
+            }
+        };
+    };
+    ringpop.proxyReq({
+        keys: [key],
+        req: allocRequest({}),
+        dest: dest,
+        res: {},
+        skipLookupOnRetry: true
+    });
+});
+
+

--- a/test/request_proxy_test.js
+++ b/test/request_proxy_test.js
@@ -113,5 +113,3 @@ test('request proxy passes down skipLookupOnRetry correctly', function t(assert)
         skipLookupOnRetry: true
     });
 });
-
-


### PR DESCRIPTION
@jwolski @markyen This allows ringpop-replicator to disable key lookups on retries, and hence fixes the following issue:

> Before retrying, ringpop looks up the destination for the given keys again, and if it finds the keys are
> now mapped to more than one destination, ringpop will return the "Destinations for proxied request 
> have diverged" error. This behavior is not compatible with replication because the lookup during 
> retries does not account for the replicas destinations.